### PR TITLE
updated Osquery scripts

### DIFF
--- a/extension-attributes/Osquery Server.sh
+++ b/extension-attributes/Osquery Server.sh
@@ -5,8 +5,8 @@
 #            Name:  Osquery Server.sh
 #     Description:  Returns tls_hostname attribute from osquery.flags (if present).
 #         Created:  2017-09-07
-#   Last Modified:  2020-07-08
-#         Version:  1.1.1
+#   Last Modified:  2022-06-27
+#         Version:  1.1.2
 #
 #
 # Copyright 2017 Palantir Technologies, Inc.
@@ -33,6 +33,7 @@
 
 
 osqueryFlagsPath="/var/osquery/osquery.flags"
+osqueryServer=""
 
 
 
@@ -43,13 +44,11 @@ osqueryFlagsPath="/var/osquery/osquery.flags"
 # Check for presence of target file and get server.
 if [ -e "$osqueryFlagsPath" ]; then
   osqueryServer=$(/usr/bin/awk -F[=] '/tls_hostname/ {print $2}' "$osqueryFlagsPath")
-else
-  osqueryServer=""
 fi
 
 
 # Report result.
-echo "<result>$osqueryServer</result>"
+echo "<result>${osqueryServer}</result>"
 
 
 

--- a/extension-attributes/Osquery Version.sh
+++ b/extension-attributes/Osquery Version.sh
@@ -5,8 +5,8 @@
 #            Name:  Osquery Version.sh
 #     Description:  Returns Osquery version (if installed).
 #         Created:  2017-07-13
-#   Last Modified:  2020-07-08
-#         Version:  2.2.1
+#   Last Modified:  2022-06-27
+#         Version:  3.0
 #
 #
 # Copyright 2017 Palantir Technologies, Inc.
@@ -32,7 +32,9 @@
 
 
 
-osquerydPath="/usr/local/bin/osqueryd"
+osqueryAppPath="/opt/osquery/lib/osquery.app"
+osquerydLegacyPath="/usr/local/bin/osqueryd"
+osqueryVersion=""
 
 
 
@@ -40,16 +42,20 @@ osquerydPath="/usr/local/bin/osqueryd"
 
 
 
-# Check for presence of target binary and get version.
-if [ -e "$osquerydPath" ]; then
-  osqueryVersion=$("$osquerydPath" --version | /usr/bin/awk '{print $3}')
-else
-  osqueryVersion=""
+# Check for presence of target application (or legacy binary) and get version.
+if [ -d "$osqueryAppPath" ]; then
+  if [ -e "${osqueryAppPath}/Contents/Info.plist" ]; then
+    osqueryVersion=$(/usr/bin/defaults read "${osqueryAppPath}/Contents/Info.plist" CFBundleVersion)
+  else
+    osqueryVersion="missing Info.plist"
+  fi
+elif [ -e "$osquerydLegacyPath" ]; then
+  osqueryVersion=$("$osquerydLegacyPath" --version | /usr/bin/awk '{print $3}')
 fi
 
 
 # Report result.
-echo "<result>$osqueryVersion</result>"
+echo "<result>${osqueryVersion}</result>"
 
 
 

--- a/scripts/script-templates/uninstaller-template/Uninstall Osquery.sh
+++ b/scripts/script-templates/uninstaller-template/Uninstall Osquery.sh
@@ -12,8 +12,8 @@
 #                   removes all associated files.
 #                   https://github.com/palantir/jamf-pro-scripts/tree/main/scripts/script-templates/uninstaller-template
 #         Created:  2017-10-23
-#   Last Modified:  2022-06-03
-#         Version:  1.3.9pal1
+#   Last Modified:  2022-06-27
+#         Version:  1.3.9pal2
 #
 #
 # Copyright 2017 Palantir Technologies, Inc.
@@ -77,6 +77,7 @@ resourceFiles=(
   "/private/var/log/osquery"
   "/private/var/osquery"
   "/usr/local/bin/osqueryctl"
+  "/usr/local/bin/osqueryd"
   "/usr/local/bin/osqueryi"
 )
 


### PR DESCRIPTION
- updated Osquery Version to detect 5.x installs (calls legacy osqueryd binary as fallback)
- updated Uninstall Osquery to remove osqueryd