### PR TITLE
removed echo for process not running

### DIFF
--- a/extension-attributes/Firmware Password Set.sh
+++ b/extension-attributes/Firmware Password Set.sh
@@ -5,8 +5,8 @@
 #            Name:  Firmware Password Set.sh
 #     Description:  Reports whether a firmware password is set on an Intel Mac.
 #         Created:  2020-01-17
-#   Last Modified:  2023-03-31
-#         Version:  1.1
+#   Last Modified:  2023-05-02
+#         Version:  1.1.1
 #
 #
 # Copyright 2020 Palantir Technologies, Inc.
@@ -41,7 +41,7 @@ firmwarePasswordSet=""
 
 
 # Display whether or not a firmware password is set on an Intel Mac.
-if $(/usr/bin/arch) = "i386"; then
+if /usr/bin/arch | /usr/bin/grep -q "i386"; then
   firmwarePasswordSet=$(/usr/sbin/firmwarepasswd -check | /usr/bin/awk '/Enabled/ {print $NF}')
 fi
 

--- a/scripts/script-templates/uninstaller-template/Uninstall Adobe AIR.sh
+++ b/scripts/script-templates/uninstaller-template/Uninstall Adobe AIR.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# shellcheck disable=SC2034
 
 ###
 #
@@ -37,9 +36,9 @@
 # ENVIRONMENT VARIABLES (leave as-is)
 loggedInUser=$(/usr/bin/stat -f%Su "/dev/console")
 # For any file paths used later in this script, use "$loggedInUserHome" for the current user's home folder path. Don't just assume the home folder is at /Users/${loggedInUser}.
+# shellcheck disable=SC2034
 loggedInUserHome=$(/usr/bin/dscl . -read "/Users/${loggedInUser}" NFSHomeDirectory | /usr/bin/awk '{print $NF}')
 loggedInUserUID=$(/usr/bin/id -u "$loggedInUser")
-currentProcesses=$(/bin/ps aux)
 launchAgentCheck=$(/bin/launchctl asuser "$loggedInUserUID" /bin/launchctl list)
 launchDaemonCheck=$(/bin/launchctl list)
 
@@ -88,6 +87,7 @@ run_vendor_uninstallers () {
 
 # Quits target processes.
 quit_processes () {
+  currentProcesses=$(/bin/ps aux)
   for process in "${processNames[@]}"; do
     if echo "$currentProcesses" | /usr/bin/grep -q "$process"; then
       /bin/launchctl asuser "$loggedInUserUID" /usr/bin/osascript -e "tell application \"${process}\" to quit"

--- a/scripts/script-templates/uninstaller-template/Uninstall Adobe AIR.sh
+++ b/scripts/script-templates/uninstaller-template/Uninstall Adobe AIR.sh
@@ -1,0 +1,155 @@
+#!/bin/bash
+
+###
+#
+#            Name:  Uninstall Adobe AIR.sh
+#     Description:  A template script to assist with the uninstallation of macOS products where the vendor has missing or incomplete removal solutions. Attempts vendor uninstall by running all provided uninstallation executables, quits all running target processes, unloads all associated launchd tasks, then removes all associated files.
+#                   https://github.com/palantir/jamf-pro-scripts/tree/main/scripts/script-templates/uninstaller-template
+#         Created:  2017-10-23
+#   Last Modified:  2023-05-02
+#         Version:  1.3.10pal1
+#
+#
+# Copyright 2017 Palantir Technologies, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#
+###
+
+
+
+########## variable-ing ##########
+
+
+
+# ENVIRONMENT VARIABLES (leave as-is)
+loggedInUser=$(/usr/bin/stat -f%Su "/dev/console")
+# For any file paths used later in this script, use "$loggedInUserHome" for the current user's home folder path. Don't just assume the home folder is at /Users/${loggedInUser}.
+# shellcheck disable=SC2034
+loggedInUserHome=$(/usr/bin/dscl . -read "/Users/${loggedInUser}" NFSHomeDirectory | /usr/bin/awk '{print $NF}')
+loggedInUserUID=$(/usr/bin/id -u "$loggedInUser")
+currentProcesses=$(/bin/ps aux)
+launchAgentCheck=$(/bin/launchctl asuser "$loggedInUserUID" /bin/launchctl list)
+launchDaemonCheck=$(/bin/launchctl list)
+
+
+# VENDOR UNINSTALLERS
+# A list of file paths for vendor-provided uninstallation tools. Note that vendor uninstaller workflows may differ greatly. Some vendors may use their own command-line tools with custom flags or other workflows to accomplish this task (that's why this script exists!), so make any necessary changes to the below commands if the uninstallation workflow isn't simply calling executable files. If the vendor did not provide an uninstaller workflow, comment these array values out.
+vendorUninstallers=(
+  "/Applications/Utilities/Adobe AIR Uninstaller.app/Contents/MacOS/Adobe AIR Installer"
+)
+
+
+# PROCESSES
+# A list of application processes to target for quitting. Names should match what is displayed for the process in Activity Monitor (e.g. "Chess", not "Chess.app"). If no processes need to be quit, comment these array values out.
+processNames=(
+  "Adobe AIR Application Installer"
+  "Adobe AIR Installer"
+)
+
+
+# FILE PATHS
+# A list of full file paths to target for launchd unload and removal. Leave off trailing slashes from directory paths. If no files need to be manually deleted, comment these array values out.
+resourceFiles=(
+  "/Applications/Adobe/Flash Player/AddIns/airappinstaller"
+  "/Applications/Utilities/Adobe AIR Application Installer.app"
+  "/Applications/Utilities/Adobe AIR Uninstaller.app"
+  "/Library/Frameworks/Adobe AIR.framework"
+)
+
+
+
+########## function-ing ##########
+
+
+
+# Runs vendor uninstallers.
+run_vendor_uninstallers () {
+  for uninstaller in "${vendorUninstallers[@]}"; do
+    if [[ -e "$uninstaller" ]]; then
+      ./"${uninstaller}" -uninstall
+    else
+      echo "Vendor uninstaller not found at ${uninstaller}."
+    fi
+  done
+}
+
+
+# Quits target processes.
+quit_processes () {
+  for process in "${processNames[@]}"; do
+    if echo "$currentProcesses" | /usr/bin/grep -q "$process"; then
+      /bin/launchctl asuser "$loggedInUserUID" /usr/bin/osascript -e "tell application \"${process}\" to quit"
+      echo "Quit ${process}."
+    fi
+  done
+}
+
+
+# Removes all remaining resource files.
+delete_files () {
+  for targetFile in "${resourceFiles[@]}"; do
+    # Check if file exists.
+    if [ -e "$targetFile" ]; then
+      # Check if file is a plist.
+      if echo "$targetFile" | /usr/bin/grep -q ".plist"; then
+        # If plist is loaded as LaunchAgent or LaunchDaemon, unload it.
+        justThePlist=$(/usr/bin/basename "$targetFile" | /usr/bin/awk -F.plist '{print $1}')
+        if echo "$launchAgentCheck" | /usr/bin/grep -q "$justThePlist"; then
+          /bin/launchctl asuser "$loggedInUserUID" /bin/launchctl unload "$targetFile"
+          echo "Unloaded LaunchAgent at ${targetFile}."
+        elif echo "$launchDaemonCheck" | /usr/bin/grep -q "$justThePlist"; then
+          /bin/launchctl unload "$targetFile"
+          echo "Unloaded LaunchDaemon at ${targetFile}."
+        fi
+      fi
+      # Remove system immutable flag if present.
+      if /bin/ls -ldO "$targetFile" | /usr/bin/awk '{print $5}' | /usr/bin/grep -q "schg"; then
+        /usr/bin/chflags -R noschg "$targetFile"
+        echo "Removed system immutable flag for ${targetFile}."
+      fi
+      # Remove file.
+      /bin/rm -rf "$targetFile"
+      echo "Removed ${targetFile}."
+    fi
+  done
+}
+
+
+
+########## main process ##########
+
+
+
+# Each function will only execute if the respective source array is not empty or undefined.
+if [[ -n "${vendorUninstallers[*]}" ]]; then
+  echo "Running vendor uninstallers..."
+  run_vendor_uninstallers
+fi
+
+
+if [[ -n "${processNames[*]}" ]]; then
+  echo "Quitting processes (if running)..."
+  quit_processes
+fi
+
+
+if [[ -n "${resourceFiles[*]}" ]]; then
+  echo "Removing files (if present)..."
+  delete_files
+fi
+
+
+
+exit 0

--- a/scripts/script-templates/uninstaller-template/Uninstall Adobe AIR.sh
+++ b/scripts/script-templates/uninstaller-template/Uninstall Adobe AIR.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# shellcheck disable=SC2034
 
 ###
 #
@@ -36,7 +37,6 @@
 # ENVIRONMENT VARIABLES (leave as-is)
 loggedInUser=$(/usr/bin/stat -f%Su "/dev/console")
 # For any file paths used later in this script, use "$loggedInUserHome" for the current user's home folder path. Don't just assume the home folder is at /Users/${loggedInUser}.
-# shellcheck disable=SC2034
 loggedInUserHome=$(/usr/bin/dscl . -read "/Users/${loggedInUser}" NFSHomeDirectory | /usr/bin/awk '{print $NF}')
 loggedInUserUID=$(/usr/bin/id -u "$loggedInUser")
 currentProcesses=$(/bin/ps aux)

--- a/scripts/script-templates/uninstaller-template/Uninstall Adobe Acrobat Reader.sh
+++ b/scripts/script-templates/uninstaller-template/Uninstall Adobe Acrobat Reader.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# shellcheck disable=SC2034
 
 ###
 #
@@ -37,9 +36,9 @@
 # ENVIRONMENT VARIABLES (leave as-is)
 loggedInUser=$(/usr/bin/stat -f%Su "/dev/console")
 # For any file paths used later in this script, use "$loggedInUserHome" for the current user's home folder path. Don't just assume the home folder is at /Users/${loggedInUser}.
+# shellcheck disable=SC2034
 loggedInUserHome=$(/usr/bin/dscl . -read "/Users/${loggedInUser}" NFSHomeDirectory | /usr/bin/awk '{print $NF}')
 loggedInUserUID=$(/usr/bin/id -u "$loggedInUser")
-currentProcesses=$(/bin/ps aux)
 launchAgentCheck=$(/bin/launchctl asuser "$loggedInUserUID" /bin/launchctl list)
 launchDaemonCheck=$(/bin/launchctl list)
 

--- a/scripts/script-templates/uninstaller-template/Uninstall Adobe Acrobat Reader.sh
+++ b/scripts/script-templates/uninstaller-template/Uninstall Adobe Acrobat Reader.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# shellcheck disable=SC2034
 
 ###
 #
@@ -36,7 +37,6 @@
 # ENVIRONMENT VARIABLES (leave as-is)
 loggedInUser=$(/usr/bin/stat -f%Su "/dev/console")
 # For any file paths used later in this script, use "$loggedInUserHome" for the current user's home folder path. Don't just assume the home folder is at /Users/${loggedInUser}.
-# shellcheck disable=SC2034
 loggedInUserHome=$(/usr/bin/dscl . -read "/Users/${loggedInUser}" NFSHomeDirectory | /usr/bin/awk '{print $NF}')
 loggedInUserUID=$(/usr/bin/id -u "$loggedInUser")
 currentProcesses=$(/bin/ps aux)

--- a/scripts/script-templates/uninstaller-template/Uninstall Adobe Acrobat Reader.sh
+++ b/scripts/script-templates/uninstaller-template/Uninstall Adobe Acrobat Reader.sh
@@ -1,0 +1,103 @@
+#!/bin/bash
+
+###
+#
+#            Name:  Uninstall Adobe Acrobat Reader.sh
+#     Description:  A template script to assist with the uninstallation of macOS products where the vendor has missing or incomplete removal solutions. Attempts vendor uninstall by running all provided uninstallation executables, quits all running target processes, unloads all associated launchd tasks, then removes all associated files.
+#                   https://github.com/palantir/jamf-pro-scripts/tree/main/scripts/script-templates/uninstaller-template
+#         Created:  2017-10-23
+#   Last Modified:  2023-05-02
+#         Version:  1.3.10pal1
+#
+#
+# Copyright 2017 Palantir Technologies, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#
+###
+
+
+
+########## variable-ing ##########
+
+
+
+# ENVIRONMENT VARIABLES (leave as-is)
+loggedInUser=$(/usr/bin/stat -f%Su "/dev/console")
+# For any file paths used later in this script, use "$loggedInUserHome" for the current user's home folder path. Don't just assume the home folder is at /Users/${loggedInUser}.
+# shellcheck disable=SC2034
+loggedInUserHome=$(/usr/bin/dscl . -read "/Users/${loggedInUser}" NFSHomeDirectory | /usr/bin/awk '{print $NF}')
+loggedInUserUID=$(/usr/bin/id -u "$loggedInUser")
+currentProcesses=$(/bin/ps aux)
+launchAgentCheck=$(/bin/launchctl asuser "$loggedInUserUID" /bin/launchctl list)
+launchDaemonCheck=$(/bin/launchctl list)
+
+
+# FILE PATHS
+# A list of full file paths to target for launchd unload and removal. Leave off trailing slashes from directory paths. If no files need to be manually deleted, comment these array values out.
+resourceFiles=(
+  "/Applications/Adobe Acrobat Reader DC.app"
+  "/Applications/Adobe Reader.app"
+)
+
+
+
+########## function-ing ##########
+
+
+
+# Removes all remaining resource files.
+delete_files () {
+  for targetFile in "${resourceFiles[@]}"; do
+    # Check if file exists.
+    if [ -e "$targetFile" ]; then
+      # Check if file is a plist.
+      if echo "$targetFile" | /usr/bin/grep -q ".plist"; then
+        # If plist is loaded as LaunchAgent or LaunchDaemon, unload it.
+        justThePlist=$(/usr/bin/basename "$targetFile" | /usr/bin/awk -F.plist '{print $1}')
+        if echo "$launchAgentCheck" | /usr/bin/grep -q "$justThePlist"; then
+          /bin/launchctl asuser "$loggedInUserUID" /bin/launchctl unload "$targetFile"
+          echo "Unloaded LaunchAgent at ${targetFile}."
+        elif echo "$launchDaemonCheck" | /usr/bin/grep -q "$justThePlist"; then
+          /bin/launchctl unload "$targetFile"
+          echo "Unloaded LaunchDaemon at ${targetFile}."
+        fi
+      fi
+      # Remove system immutable flag if present.
+      if /bin/ls -ldO "$targetFile" | /usr/bin/awk '{print $5}' | /usr/bin/grep -q "schg"; then
+        /usr/bin/chflags -R noschg "$targetFile"
+        echo "Removed system immutable flag for ${targetFile}."
+      fi
+      # Remove file.
+      /bin/rm -rf "$targetFile"
+      echo "Removed ${targetFile}."
+    fi
+  done
+}
+
+
+
+########## main process ##########
+
+
+
+# Each function will only execute if the respective source array is not empty or undefined.
+if [[ -n "${resourceFiles[*]}" ]]; then
+  echo "Removing files (if present)..."
+  delete_files
+fi
+
+
+
+exit 0

--- a/scripts/script-templates/uninstaller-template/Uninstall Adobe Acrobat.sh
+++ b/scripts/script-templates/uninstaller-template/Uninstall Adobe Acrobat.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# shellcheck disable=SC2034
 
 ###
 #
@@ -37,9 +36,9 @@
 # ENVIRONMENT VARIABLES (leave as-is)
 loggedInUser=$(/usr/bin/stat -f%Su "/dev/console")
 # For any file paths used later in this script, use "$loggedInUserHome" for the current user's home folder path. Don't just assume the home folder is at /Users/${loggedInUser}.
+# shellcheck disable=SC2034
 loggedInUserHome=$(/usr/bin/dscl . -read "/Users/${loggedInUser}" NFSHomeDirectory | /usr/bin/awk '{print $NF}')
 loggedInUserUID=$(/usr/bin/id -u "$loggedInUser")
-currentProcesses=$(/bin/ps aux)
 launchAgentCheck=$(/bin/launchctl asuser "$loggedInUserUID" /bin/launchctl list)
 launchDaemonCheck=$(/bin/launchctl list)
 

--- a/scripts/script-templates/uninstaller-template/Uninstall Adobe Acrobat.sh
+++ b/scripts/script-templates/uninstaller-template/Uninstall Adobe Acrobat.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# shellcheck disable=SC2034
 
 ###
 #
@@ -36,7 +37,6 @@
 # ENVIRONMENT VARIABLES (leave as-is)
 loggedInUser=$(/usr/bin/stat -f%Su "/dev/console")
 # For any file paths used later in this script, use "$loggedInUserHome" for the current user's home folder path. Don't just assume the home folder is at /Users/${loggedInUser}.
-# shellcheck disable=SC2034
 loggedInUserHome=$(/usr/bin/dscl . -read "/Users/${loggedInUser}" NFSHomeDirectory | /usr/bin/awk '{print $NF}')
 loggedInUserUID=$(/usr/bin/id -u "$loggedInUser")
 currentProcesses=$(/bin/ps aux)

--- a/scripts/script-templates/uninstaller-template/Uninstall Adobe Acrobat.sh
+++ b/scripts/script-templates/uninstaller-template/Uninstall Adobe Acrobat.sh
@@ -1,0 +1,103 @@
+#!/bin/bash
+
+###
+#
+#            Name:  Uninstall Adobe Acrobat.sh
+#     Description:  A template script to assist with the uninstallation of macOS products where the vendor has missing or incomplete removal solutions. Attempts vendor uninstall by running all provided uninstallation executables, quits all running target processes, unloads all associated launchd tasks, then removes all associated files.
+#                   https://github.com/palantir/jamf-pro-scripts/tree/main/scripts/script-templates/uninstaller-template
+#         Created:  2017-10-23
+#   Last Modified:  2023-05-02
+#         Version:  1.3.10pal1
+#
+#
+# Copyright 2017 Palantir Technologies, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#
+###
+
+
+
+########## variable-ing ##########
+
+
+
+# ENVIRONMENT VARIABLES (leave as-is)
+loggedInUser=$(/usr/bin/stat -f%Su "/dev/console")
+# For any file paths used later in this script, use "$loggedInUserHome" for the current user's home folder path. Don't just assume the home folder is at /Users/${loggedInUser}.
+# shellcheck disable=SC2034
+loggedInUserHome=$(/usr/bin/dscl . -read "/Users/${loggedInUser}" NFSHomeDirectory | /usr/bin/awk '{print $NF}')
+loggedInUserUID=$(/usr/bin/id -u "$loggedInUser")
+currentProcesses=$(/bin/ps aux)
+launchAgentCheck=$(/bin/launchctl asuser "$loggedInUserUID" /bin/launchctl list)
+launchDaemonCheck=$(/bin/launchctl list)
+
+
+# FILE PATHS
+# A list of full file paths to target for launchd unload and removal. Leave off trailing slashes from directory paths. If no files need to be manually deleted, comment these array values out.
+resourceFiles=(
+  "/Applications/Adobe Acrobat DC/Adobe Acrobat.app"
+  "/Applications/Adobe Acrobat DC"
+)
+
+
+
+########## function-ing ##########
+
+
+
+# Removes all remaining resource files.
+delete_files () {
+  for targetFile in "${resourceFiles[@]}"; do
+    # Check if file exists.
+    if [ -e "$targetFile" ]; then
+      # Check if file is a plist.
+      if echo "$targetFile" | /usr/bin/grep -q ".plist"; then
+        # If plist is loaded as LaunchAgent or LaunchDaemon, unload it.
+        justThePlist=$(/usr/bin/basename "$targetFile" | /usr/bin/awk -F.plist '{print $1}')
+        if echo "$launchAgentCheck" | /usr/bin/grep -q "$justThePlist"; then
+          /bin/launchctl asuser "$loggedInUserUID" /bin/launchctl unload "$targetFile"
+          echo "Unloaded LaunchAgent at ${targetFile}."
+        elif echo "$launchDaemonCheck" | /usr/bin/grep -q "$justThePlist"; then
+          /bin/launchctl unload "$targetFile"
+          echo "Unloaded LaunchDaemon at ${targetFile}."
+        fi
+      fi
+      # Remove system immutable flag if present.
+      if /bin/ls -ldO "$targetFile" | /usr/bin/awk '{print $5}' | /usr/bin/grep -q "schg"; then
+        /usr/bin/chflags -R noschg "$targetFile"
+        echo "Removed system immutable flag for ${targetFile}."
+      fi
+      # Remove file.
+      /bin/rm -rf "$targetFile"
+      echo "Removed ${targetFile}."
+    fi
+  done
+}
+
+
+
+########## main process ##########
+
+
+
+# Each function will only execute if the respective source array is not empty or undefined.
+if [[ -n "${resourceFiles[*]}" ]]; then
+  echo "Removing files (if present)..."
+  delete_files
+fi
+
+
+
+exit 0

--- a/scripts/script-templates/uninstaller-template/Uninstall Adobe Application.sh
+++ b/scripts/script-templates/uninstaller-template/Uninstall Adobe Application.sh
@@ -1,0 +1,125 @@
+#!/bin/bash
+
+###
+#
+#            Name:  Uninstall Adobe Application.sh
+#     Description:  A template script to assist with the uninstallation of macOS products where the vendor has missing or incomplete removal solutions. Attempts vendor uninstall by running all provided uninstallation executables, quits all running target processes, unloads all associated launchd tasks, then removes all associated files.
+#                   https://github.com/palantir/jamf-pro-scripts/tree/main/scripts/script-templates/uninstaller-template
+#         Created:  2017-10-23
+#   Last Modified:  2023-05-02
+#         Version:  1.3.10pal1
+#
+#
+# Copyright 2017 Palantir Technologies, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#
+###
+
+
+
+########## variable-ing ##########
+
+
+
+# Jamf Pro script parameter: "Adobe Application Name"
+adobeAppName="${4}"
+# Jamf Pro script parameter: "Adobe Application Year"
+adobeAppYear="${5}"
+
+
+# ENVIRONMENT VARIABLES (leave as-is)
+loggedInUser=$(/usr/bin/stat -f%Su "/dev/console")
+# For any file paths used later in this script, use "$loggedInUserHome" for the current user's home folder path. Don't just assume the home folder is at /Users/${loggedInUser}.
+# shellcheck disable=SC2034
+loggedInUserHome=$(/usr/bin/dscl . -read "/Users/${loggedInUser}" NFSHomeDirectory | /usr/bin/awk '{print $NF}')
+loggedInUserUID=$(/usr/bin/id -u "$loggedInUser")
+currentProcesses=$(/bin/ps aux)
+launchAgentCheck=$(/bin/launchctl asuser "$loggedInUserUID" /bin/launchctl list)
+launchDaemonCheck=$(/bin/launchctl list)
+
+
+# FILE PATHS
+# A list of full file paths to target for launchd unload and removal. Leave off trailing slashes from directory paths. If no files need to be manually deleted, comment these array values out.
+resourceFiles=(
+  "/Applications/Adobe ${adobeAppName} CC ${adobeAppYear}/Adobe ${adobeAppName} CC ${adobeAppYear}.app"
+  "/Applications/Adobe ${adobeAppName} CC ${adobeAppYear}"
+  "/Applications/Adobe ${adobeAppName} ${adobeAppYear}/Adobe ${adobeAppName} ${adobeAppYear}.app"
+  "/Applications/Adobe ${adobeAppName} ${adobeAppYear}"
+)
+
+
+
+########## function-ing ##########
+
+
+
+# Exits if any required Jamf Pro arguments are undefined.
+check_jamf_pro_arguments () {
+  if [ -z "$adobeAppName" ] || [ -z "$adobeAppYear" ]; then
+    echo "❌ ERROR: Undefined Jamf Pro argument, unable to proceed."
+    exit 74
+  fi
+}
+
+
+# Removes all remaining resource files.
+delete_files () {
+  for targetFile in "${resourceFiles[@]}"; do
+    # Check if file exists.
+    if [ -e "$targetFile" ]; then
+      # Check if file is a plist.
+      if echo "$targetFile" | /usr/bin/grep -q ".plist"; then
+        # If plist is loaded as LaunchAgent or LaunchDaemon, unload it.
+        justThePlist=$(/usr/bin/basename "$targetFile" | /usr/bin/awk -F.plist '{print $1}')
+        if echo "$launchAgentCheck" | /usr/bin/grep -q "$justThePlist"; then
+          /bin/launchctl asuser "$loggedInUserUID" /bin/launchctl unload "$targetFile"
+          echo "Unloaded LaunchAgent at ${targetFile}."
+        elif echo "$launchDaemonCheck" | /usr/bin/grep -q "$justThePlist"; then
+          /bin/launchctl unload "$targetFile"
+          echo "Unloaded LaunchDaemon at ${targetFile}."
+        fi
+      fi
+      # Remove system immutable flag if present.
+      if /bin/ls -ldO "$targetFile" | /usr/bin/awk '{print $5}' | /usr/bin/grep -q "schg"; then
+        /usr/bin/chflags -R noschg "$targetFile"
+        echo "Removed system immutable flag for ${targetFile}."
+      fi
+      # Remove file.
+      /bin/rm -rf "$targetFile"
+      echo "Removed ${targetFile}."
+    fi
+  done
+}
+
+
+
+########## main process ##########
+
+
+
+# Check script prerequisites.
+check_jamf_pro_arguments
+
+
+# Each function will only execute if the respective source array is not empty or undefined.
+
+if [[ -n "${resourceFiles[*]}" ]]; then
+  echo "Removing files (if present)..."
+  delete_files
+fi
+
+
+
+exit 0

--- a/scripts/script-templates/uninstaller-template/Uninstall Adobe Application.sh
+++ b/scripts/script-templates/uninstaller-template/Uninstall Adobe Application.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# shellcheck disable=SC2034
 
 ###
 #
@@ -43,9 +42,9 @@ adobeAppYear="${5}"
 # ENVIRONMENT VARIABLES (leave as-is)
 loggedInUser=$(/usr/bin/stat -f%Su "/dev/console")
 # For any file paths used later in this script, use "$loggedInUserHome" for the current user's home folder path. Don't just assume the home folder is at /Users/${loggedInUser}.
+# shellcheck disable=SC2034
 loggedInUserHome=$(/usr/bin/dscl . -read "/Users/${loggedInUser}" NFSHomeDirectory | /usr/bin/awk '{print $NF}')
 loggedInUserUID=$(/usr/bin/id -u "$loggedInUser")
-currentProcesses=$(/bin/ps aux)
 launchAgentCheck=$(/bin/launchctl asuser "$loggedInUserUID" /bin/launchctl list)
 launchDaemonCheck=$(/bin/launchctl list)
 

--- a/scripts/script-templates/uninstaller-template/Uninstall Adobe Application.sh
+++ b/scripts/script-templates/uninstaller-template/Uninstall Adobe Application.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# shellcheck disable=SC2034
 
 ###
 #
@@ -42,7 +43,6 @@ adobeAppYear="${5}"
 # ENVIRONMENT VARIABLES (leave as-is)
 loggedInUser=$(/usr/bin/stat -f%Su "/dev/console")
 # For any file paths used later in this script, use "$loggedInUserHome" for the current user's home folder path. Don't just assume the home folder is at /Users/${loggedInUser}.
-# shellcheck disable=SC2034
 loggedInUserHome=$(/usr/bin/dscl . -read "/Users/${loggedInUser}" NFSHomeDirectory | /usr/bin/awk '{print $NF}')
 loggedInUserUID=$(/usr/bin/id -u "$loggedInUser")
 currentProcesses=$(/bin/ps aux)

--- a/scripts/script-templates/uninstaller-template/Uninstall Adobe Creative Cloud Desktop.sh
+++ b/scripts/script-templates/uninstaller-template/Uninstall Adobe Creative Cloud Desktop.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# shellcheck disable=SC2034
 
 ###
 #
@@ -37,9 +36,9 @@
 # ENVIRONMENT VARIABLES (leave as-is)
 loggedInUser=$(/usr/bin/stat -f%Su "/dev/console")
 # For any file paths used later in this script, use "$loggedInUserHome" for the current user's home folder path. Don't just assume the home folder is at /Users/${loggedInUser}.
+# shellcheck disable=SC2034
 loggedInUserHome=$(/usr/bin/dscl . -read "/Users/${loggedInUser}" NFSHomeDirectory | /usr/bin/awk '{print $NF}')
 loggedInUserUID=$(/usr/bin/id -u "$loggedInUser")
-currentProcesses=$(/bin/ps aux)
 launchAgentCheck=$(/bin/launchctl asuser "$loggedInUserUID" /bin/launchctl list)
 launchDaemonCheck=$(/bin/launchctl list)
 

--- a/scripts/script-templates/uninstaller-template/Uninstall Adobe Creative Cloud Desktop.sh
+++ b/scripts/script-templates/uninstaller-template/Uninstall Adobe Creative Cloud Desktop.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# shellcheck disable=SC2034
 
 ###
 #
@@ -36,7 +37,6 @@
 # ENVIRONMENT VARIABLES (leave as-is)
 loggedInUser=$(/usr/bin/stat -f%Su "/dev/console")
 # For any file paths used later in this script, use "$loggedInUserHome" for the current user's home folder path. Don't just assume the home folder is at /Users/${loggedInUser}.
-# shellcheck disable=SC2034
 loggedInUserHome=$(/usr/bin/dscl . -read "/Users/${loggedInUser}" NFSHomeDirectory | /usr/bin/awk '{print $NF}')
 loggedInUserUID=$(/usr/bin/id -u "$loggedInUser")
 currentProcesses=$(/bin/ps aux)

--- a/scripts/script-templates/uninstaller-template/Uninstall Adobe Creative Cloud Desktop.sh
+++ b/scripts/script-templates/uninstaller-template/Uninstall Adobe Creative Cloud Desktop.sh
@@ -1,0 +1,112 @@
+#!/bin/bash
+
+###
+#
+#            Name:  Uninstall Adobe Creative Cloud Desktop.sh
+#     Description:  A template script to assist with the uninstallation of macOS products where the vendor has missing or incomplete removal solutions. Attempts vendor uninstall by running all provided uninstallation executables, quits all running target processes, unloads all associated launchd tasks, then removes all associated files.
+#                   https://github.com/palantir/jamf-pro-scripts/tree/main/scripts/script-templates/uninstaller-template
+#         Created:  2017-10-23
+#   Last Modified:  2023-05-02
+#         Version:  1.3.10pal1
+#
+#
+# Copyright 2017 Palantir Technologies, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#
+###
+
+
+
+########## variable-ing ##########
+
+
+
+# ENVIRONMENT VARIABLES (leave as-is)
+loggedInUser=$(/usr/bin/stat -f%Su "/dev/console")
+# For any file paths used later in this script, use "$loggedInUserHome" for the current user's home folder path. Don't just assume the home folder is at /Users/${loggedInUser}.
+# shellcheck disable=SC2034
+loggedInUserHome=$(/usr/bin/dscl . -read "/Users/${loggedInUser}" NFSHomeDirectory | /usr/bin/awk '{print $NF}')
+loggedInUserUID=$(/usr/bin/id -u "$loggedInUser")
+currentProcesses=$(/bin/ps aux)
+launchAgentCheck=$(/bin/launchctl asuser "$loggedInUserUID" /bin/launchctl list)
+launchDaemonCheck=$(/bin/launchctl list)
+
+
+# FILE PATHS
+# A list of full file paths to target for launchd unload and removal. Leave off trailing slashes from directory paths. If no files need to be manually deleted, comment these array values out.
+resourceFiles=(
+  "/Applications/Utilities/Adobe Creative Cloud/ACC/Creative Cloud.app"
+  "/Applications/Utilities/Adobe Creative Cloud/AppsPanel/Updater/Adobe Application Updater.app"
+  "/Applications/Utilities/Adobe Creative Cloud/CCXProcess/CCXProcess.app"
+  "/Applications/Utilities/Adobe Creative Cloud/HDCore/Install.app"
+  "/Applications/Utilities/Adobe Creative Cloud/HDCore/Uninstaller.app"
+  "/Applications/Utilities/Adobe Creative Cloud/Utils/Creative Cloud Desktop App.app"
+  "/Applications/Utilities/Adobe Creative Cloud/Utils/Creative Cloud Installer.app"
+  "/Applications/Utilities/Adobe Creative Cloud/Utils/Creative Cloud Uninstaller.app"
+  "/Applications/Utilities/Adobe Creative Cloud/"
+  "/Applications/Utilities/Adobe Creative Cloud Experience/CCXProcess.app"
+  "/Applications/Utilities/Adobe Creative Cloud Experience"
+)
+
+
+
+########## function-ing ##########
+
+
+
+# Removes all remaining resource files.
+delete_files () {
+  for targetFile in "${resourceFiles[@]}"; do
+    # Check if file exists.
+    if [ -e "$targetFile" ]; then
+      # Check if file is a plist.
+      if echo "$targetFile" | /usr/bin/grep -q ".plist"; then
+        # If plist is loaded as LaunchAgent or LaunchDaemon, unload it.
+        justThePlist=$(/usr/bin/basename "$targetFile" | /usr/bin/awk -F.plist '{print $1}')
+        if echo "$launchAgentCheck" | /usr/bin/grep -q "$justThePlist"; then
+          /bin/launchctl asuser "$loggedInUserUID" /bin/launchctl unload "$targetFile"
+          echo "Unloaded LaunchAgent at ${targetFile}."
+        elif echo "$launchDaemonCheck" | /usr/bin/grep -q "$justThePlist"; then
+          /bin/launchctl unload "$targetFile"
+          echo "Unloaded LaunchDaemon at ${targetFile}."
+        fi
+      fi
+      # Remove system immutable flag if present.
+      if /bin/ls -ldO "$targetFile" | /usr/bin/awk '{print $5}' | /usr/bin/grep -q "schg"; then
+        /usr/bin/chflags -R noschg "$targetFile"
+        echo "Removed system immutable flag for ${targetFile}."
+      fi
+      # Remove file.
+      /bin/rm -rf "$targetFile"
+      echo "Removed ${targetFile}."
+    fi
+  done
+}
+
+
+
+########## main process ##########
+
+
+
+# Each function will only execute if the respective source array is not empty or undefined.
+if [[ -n "${resourceFiles[*]}" ]]; then
+  echo "Removing files (if present)..."
+  delete_files
+fi
+
+
+
+exit 0

--- a/scripts/script-templates/uninstaller-template/Uninstall Adobe Flash.sh
+++ b/scripts/script-templates/uninstaller-template/Uninstall Adobe Flash.sh
@@ -3,17 +3,11 @@
 ###
 #
 #            Name:  Uninstall Adobe Flash.sh
-#     Description:  A template script to assist with the uninstallation of
-#                   macOS products where the vendor has missing or incomplete
-#                   removal solutions.
-#                   Attempts vendor uninstall by running all provided
-#                   uninstallation executables, quits all running target
-#                   processes, unloads all associated launchd tasks, then
-#                   removes all associated files.
+#     Description:  A template script to assist with the uninstallation of macOS products where the vendor has missing or incomplete removal solutions. Attempts vendor uninstall by running all provided uninstallation executables, quits all running target processes, unloads all associated launchd tasks, then removes all associated files.
 #                   https://github.com/palantir/jamf-pro-scripts/tree/main/scripts/script-templates/uninstaller-template
 #         Created:  2017-10-23
-#   Last Modified:  2022-06-03
-#         Version:  1.3.9pal1
+#   Last Modified:  2023-05-02
+#         Version:  1.3.10pal1
 #
 #
 # Copyright 2017 Palantir Technologies, Inc.
@@ -39,11 +33,9 @@
 
 
 
-# ENVIRONMENT VARIABLES (leave as-is):
+# ENVIRONMENT VARIABLES (leave as-is)
 loggedInUser=$(/usr/bin/stat -f%Su "/dev/console")
-# For any file paths used later in this script, use "$loggedInUserHome" for the
-# current user's home folder path. Don't just assume the home folder is at
-# /Users/$loggedInUser.
+# For any file paths used later in this script, use "$loggedInUserHome" for the current user's home folder path. Don't just assume the home folder is at /Users/${loggedInUser}.
 # shellcheck disable=SC2034
 loggedInUserHome=$(/usr/bin/dscl . -read "/Users/${loggedInUser}" NFSHomeDirectory | /usr/bin/awk '{print $NF}')
 loggedInUserUID=$(/usr/bin/id -u "$loggedInUser")
@@ -52,22 +44,15 @@ launchAgentCheck=$(/bin/launchctl asuser "$loggedInUserUID" /bin/launchctl list)
 launchDaemonCheck=$(/bin/launchctl list)
 
 
-# PROCESSES:
-# A list of application processes to target for quitting.
-# Names should match what is displayed for the process in Activity Monitor
-# (e.g. "Chess", not "Chess.app").
-#
-# If no processes need to be quit, comment these array values out.
+# PROCESSES
+# A list of application processes to target for quitting. Names should match what is displayed for the process in Activity Monitor (e.g. "Chess", not "Chess.app"). If no processes need to be quit, comment these array values out.
 processNames=(
   "Adobe Flash Player Install Manager"
 )
 
 
-# FILE PATHS:
-# A list of full file paths to target for launchd unload and removal.
-# Leave off trailing slashes from directory paths.
-#
-# If no files need to be manually deleted, comment these array values out.
+# FILE PATHS
+# A list of full file paths to target for launchd unload and removal. Leave off trailing slashes from directory paths. If no files need to be manually deleted, comment these array values out.
 resourceFiles=(
   "/Applications/Utilities/Adobe Flash Player Install Manager.app"
   "/Library/Internet Plug-Ins/Flash Player.plugin"
@@ -89,8 +74,6 @@ quit_processes () {
     if echo "$currentProcesses" | /usr/bin/grep -q "$process"; then
       /bin/launchctl asuser "$loggedInUserUID" /usr/bin/osascript -e "tell application \"${process}\" to quit"
       echo "Quit ${process}."
-    else
-      echo "${process} not running."
     fi
   done
 }
@@ -131,8 +114,7 @@ delete_files () {
 
 
 
-# Each function will only execute if the respective source array is not empty
-# or undefined.
+# Each function will only execute if the respective source array is not empty or undefined.
 if [[ -n "${processNames[*]}" ]]; then
   echo "Quitting processes (if running)..."
   quit_processes

--- a/scripts/script-templates/uninstaller-template/Uninstall Adobe Flash.sh
+++ b/scripts/script-templates/uninstaller-template/Uninstall Adobe Flash.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# shellcheck disable=SC2034
 
 ###
 #
@@ -36,7 +37,6 @@
 # ENVIRONMENT VARIABLES (leave as-is)
 loggedInUser=$(/usr/bin/stat -f%Su "/dev/console")
 # For any file paths used later in this script, use "$loggedInUserHome" for the current user's home folder path. Don't just assume the home folder is at /Users/${loggedInUser}.
-# shellcheck disable=SC2034
 loggedInUserHome=$(/usr/bin/dscl . -read "/Users/${loggedInUser}" NFSHomeDirectory | /usr/bin/awk '{print $NF}')
 loggedInUserUID=$(/usr/bin/id -u "$loggedInUser")
 currentProcesses=$(/bin/ps aux)

--- a/scripts/script-templates/uninstaller-template/Uninstall Adobe Flash.sh
+++ b/scripts/script-templates/uninstaller-template/Uninstall Adobe Flash.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# shellcheck disable=SC2034
 
 ###
 #
@@ -37,9 +36,9 @@
 # ENVIRONMENT VARIABLES (leave as-is)
 loggedInUser=$(/usr/bin/stat -f%Su "/dev/console")
 # For any file paths used later in this script, use "$loggedInUserHome" for the current user's home folder path. Don't just assume the home folder is at /Users/${loggedInUser}.
+# shellcheck disable=SC2034
 loggedInUserHome=$(/usr/bin/dscl . -read "/Users/${loggedInUser}" NFSHomeDirectory | /usr/bin/awk '{print $NF}')
 loggedInUserUID=$(/usr/bin/id -u "$loggedInUser")
-currentProcesses=$(/bin/ps aux)
 launchAgentCheck=$(/bin/launchctl asuser "$loggedInUserUID" /bin/launchctl list)
 launchDaemonCheck=$(/bin/launchctl list)
 
@@ -70,6 +69,7 @@ resourceFiles=(
 
 # Quits target processes.
 quit_processes () {
+  currentProcesses=$(/bin/ps aux)
   for process in "${processNames[@]}"; do
     if echo "$currentProcesses" | /usr/bin/grep -q "$process"; then
       /bin/launchctl asuser "$loggedInUserUID" /usr/bin/osascript -e "tell application \"${process}\" to quit"

--- a/scripts/script-templates/uninstaller-template/Uninstall AeroFS.sh
+++ b/scripts/script-templates/uninstaller-template/Uninstall AeroFS.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# shellcheck disable=SC2034
 
 ###
 #
@@ -37,9 +36,9 @@
 # ENVIRONMENT VARIABLES (leave as-is)
 loggedInUser=$(/usr/bin/stat -f%Su "/dev/console")
 # For any file paths used later in this script, use "$loggedInUserHome" for the current user's home folder path. Don't just assume the home folder is at /Users/${loggedInUser}.
+# shellcheck disable=SC2034
 loggedInUserHome=$(/usr/bin/dscl . -read "/Users/${loggedInUser}" NFSHomeDirectory | /usr/bin/awk '{print $NF}')
 loggedInUserUID=$(/usr/bin/id -u "$loggedInUser")
-currentProcesses=$(/bin/ps aux)
 launchAgentCheck=$(/bin/launchctl asuser "$loggedInUserUID" /bin/launchctl list)
 launchDaemonCheck=$(/bin/launchctl list)
 
@@ -67,6 +66,7 @@ resourceFiles=(
 
 # Quits target processes.
 quit_processes () {
+  currentProcesses=$(/bin/ps aux)
   for process in "${processNames[@]}"; do
     if echo "$currentProcesses" | /usr/bin/grep -q "$process"; then
       /bin/launchctl asuser "$loggedInUserUID" /usr/bin/osascript -e "tell application \"${process}\" to quit"

--- a/scripts/script-templates/uninstaller-template/Uninstall AeroFS.sh
+++ b/scripts/script-templates/uninstaller-template/Uninstall AeroFS.sh
@@ -3,17 +3,11 @@
 ###
 #
 #            Name:  Uninstall AeroFS.sh
-#     Description:  A template script to assist with the uninstallation of
-#                   macOS products where the vendor has missing or incomplete
-#                   removal solutions.
-#                   Attempts vendor uninstall by running all provided
-#                   uninstallation executables, quits all running target
-#                   processes, unloads all associated launchd tasks, then
-#                   removes all associated files.
+#     Description:  A template script to assist with the uninstallation of macOS products where the vendor has missing or incomplete removal solutions. Attempts vendor uninstall by running all provided uninstallation executables, quits all running target processes, unloads all associated launchd tasks, then removes all associated files.
 #                   https://github.com/palantir/jamf-pro-scripts/tree/main/scripts/script-templates/uninstaller-template
 #         Created:  2017-10-23
-#   Last Modified:  2022-06-03
-#         Version:  1.3.9pal1
+#   Last Modified:  2023-05-02
+#         Version:  1.3.10pal1
 #
 #
 # Copyright 2017 Palantir Technologies, Inc.
@@ -39,11 +33,9 @@
 
 
 
-# ENVIRONMENT VARIABLES (leave as-is):
+# ENVIRONMENT VARIABLES (leave as-is)
 loggedInUser=$(/usr/bin/stat -f%Su "/dev/console")
-# For any file paths used later in this script, use "$loggedInUserHome" for the
-# current user's home folder path. Don't just assume the home folder is at
-# /Users/$loggedInUser.
+# For any file paths used later in this script, use "$loggedInUserHome" for the current user's home folder path. Don't just assume the home folder is at /Users/${loggedInUser}.
 # shellcheck disable=SC2034
 loggedInUserHome=$(/usr/bin/dscl . -read "/Users/${loggedInUser}" NFSHomeDirectory | /usr/bin/awk '{print $NF}')
 loggedInUserUID=$(/usr/bin/id -u "$loggedInUser")
@@ -52,22 +44,15 @@ launchAgentCheck=$(/bin/launchctl asuser "$loggedInUserUID" /bin/launchctl list)
 launchDaemonCheck=$(/bin/launchctl list)
 
 
-# PROCESSES:
-# A list of application processes to target for quitting.
-# Names should match what is displayed for the process in Activity Monitor
-# (e.g. "Chess", not "Chess.app").
-#
-# If no processes need to be quit, comment these array values out.
+# PROCESSES
+# A list of application processes to target for quitting. Names should match what is displayed for the process in Activity Monitor (e.g. "Chess", not "Chess.app"). If no processes need to be quit, comment these array values out.
 processNames=(
   "AeroFS"
 )
 
 
-# FILE PATHS:
-# A list of full file paths to target for launchd unload and removal.
-# Leave off trailing slashes from directory paths.
-#
-# If no files need to be manually deleted, comment these array values out.
+# FILE PATHS
+# A list of full file paths to target for launchd unload and removal. Leave off trailing slashes from directory paths. If no files need to be manually deleted, comment these array values out.
 resourceFiles=(
   "/Applications/AeroFS.app"
   "/Library/ScriptingAdditions/AeroFSFinderExtension.osax"
@@ -86,8 +71,6 @@ quit_processes () {
     if echo "$currentProcesses" | /usr/bin/grep -q "$process"; then
       /bin/launchctl asuser "$loggedInUserUID" /usr/bin/osascript -e "tell application \"${process}\" to quit"
       echo "Quit ${process}."
-    else
-      echo "${process} not running."
     fi
   done
 }
@@ -128,8 +111,7 @@ delete_files () {
 
 
 
-# Each function will only execute if the respective source array is not empty
-# or undefined.
+# Each function will only execute if the respective source array is not empty or undefined.
 if [[ -n "${processNames[*]}" ]]; then
   echo "Quitting processes (if running)..."
   quit_processes

--- a/scripts/script-templates/uninstaller-template/Uninstall AeroFS.sh
+++ b/scripts/script-templates/uninstaller-template/Uninstall AeroFS.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# shellcheck disable=SC2034
 
 ###
 #
@@ -36,7 +37,6 @@
 # ENVIRONMENT VARIABLES (leave as-is)
 loggedInUser=$(/usr/bin/stat -f%Su "/dev/console")
 # For any file paths used later in this script, use "$loggedInUserHome" for the current user's home folder path. Don't just assume the home folder is at /Users/${loggedInUser}.
-# shellcheck disable=SC2034
 loggedInUserHome=$(/usr/bin/dscl . -read "/Users/${loggedInUser}" NFSHomeDirectory | /usr/bin/awk '{print $NF}')
 loggedInUserUID=$(/usr/bin/id -u "$loggedInUser")
 currentProcesses=$(/bin/ps aux)

--- a/scripts/script-templates/uninstaller-template/Uninstall Box Sync.sh
+++ b/scripts/script-templates/uninstaller-template/Uninstall Box Sync.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# shellcheck disable=SC2034
 
 ###
 #
@@ -36,7 +37,6 @@
 # ENVIRONMENT VARIABLES (leave as-is)
 loggedInUser=$(/usr/bin/stat -f%Su "/dev/console")
 # For any file paths used later in this script, use "$loggedInUserHome" for the current user's home folder path. Don't just assume the home folder is at /Users/${loggedInUser}.
-# shellcheck disable=SC2034
 loggedInUserHome=$(/usr/bin/dscl . -read "/Users/${loggedInUser}" NFSHomeDirectory | /usr/bin/awk '{print $NF}')
 loggedInUserUID=$(/usr/bin/id -u "$loggedInUser")
 currentProcesses=$(/bin/ps aux)

--- a/scripts/script-templates/uninstaller-template/Uninstall Box Sync.sh
+++ b/scripts/script-templates/uninstaller-template/Uninstall Box Sync.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# shellcheck disable=SC2034
 
 ###
 #
@@ -37,9 +36,9 @@
 # ENVIRONMENT VARIABLES (leave as-is)
 loggedInUser=$(/usr/bin/stat -f%Su "/dev/console")
 # For any file paths used later in this script, use "$loggedInUserHome" for the current user's home folder path. Don't just assume the home folder is at /Users/${loggedInUser}.
+# shellcheck disable=SC2034
 loggedInUserHome=$(/usr/bin/dscl . -read "/Users/${loggedInUser}" NFSHomeDirectory | /usr/bin/awk '{print $NF}')
 loggedInUserUID=$(/usr/bin/id -u "$loggedInUser")
-currentProcesses=$(/bin/ps aux)
 launchAgentCheck=$(/bin/launchctl asuser "$loggedInUserUID" /bin/launchctl list)
 launchDaemonCheck=$(/bin/launchctl list)
 
@@ -70,6 +69,7 @@ resourceFiles=(
 
 # Quits target processes.
 quit_processes () {
+  currentProcesses=$(/bin/ps aux)
   for process in "${processNames[@]}"; do
     if echo "$currentProcesses" | /usr/bin/grep -q "$process"; then
       /bin/launchctl asuser "$loggedInUserUID" /usr/bin/osascript -e "tell application \"${process}\" to quit"

--- a/scripts/script-templates/uninstaller-template/Uninstall Box Sync.sh
+++ b/scripts/script-templates/uninstaller-template/Uninstall Box Sync.sh
@@ -3,17 +3,11 @@
 ###
 #
 #            Name:  Uninstall Box Sync.sh
-#     Description:  A template script to assist with the uninstallation of
-#                   macOS products where the vendor has missing or incomplete
-#                   removal solutions.
-#                   Attempts vendor uninstall by running all provided
-#                   uninstallation executables, quits all running target
-#                   processes, unloads all associated launchd tasks, then
-#                   removes all associated files.
+#     Description:  A template script to assist with the uninstallation of macOS products where the vendor has missing or incomplete removal solutions. Attempts vendor uninstall by running all provided uninstallation executables, quits all running target processes, unloads all associated launchd tasks, then removes all associated files.
 #                   https://github.com/palantir/jamf-pro-scripts/tree/main/scripts/script-templates/uninstaller-template
 #         Created:  2017-10-23
-#   Last Modified:  2022-06-03
-#         Version:  1.3.9pal1
+#   Last Modified:  2023-05-02
+#         Version:  1.3.10pal1
 #
 #
 # Copyright 2017 Palantir Technologies, Inc.
@@ -39,11 +33,9 @@
 
 
 
-# ENVIRONMENT VARIABLES (leave as-is):
+# ENVIRONMENT VARIABLES (leave as-is)
 loggedInUser=$(/usr/bin/stat -f%Su "/dev/console")
-# For any file paths used later in this script, use "$loggedInUserHome" for the
-# current user's home folder path. Don't just assume the home folder is at
-# /Users/$loggedInUser.
+# For any file paths used later in this script, use "$loggedInUserHome" for the current user's home folder path. Don't just assume the home folder is at /Users/${loggedInUser}.
 # shellcheck disable=SC2034
 loggedInUserHome=$(/usr/bin/dscl . -read "/Users/${loggedInUser}" NFSHomeDirectory | /usr/bin/awk '{print $NF}')
 loggedInUserUID=$(/usr/bin/id -u "$loggedInUser")
@@ -52,22 +44,15 @@ launchAgentCheck=$(/bin/launchctl asuser "$loggedInUserUID" /bin/launchctl list)
 launchDaemonCheck=$(/bin/launchctl list)
 
 
-# PROCESSES:
-# A list of application processes to target for quitting.
-# Names should match what is displayed for the process in Activity Monitor
-# (e.g. "Chess", not "Chess.app").
-#
-# If no processes need to be quit, comment these array values out.
+# PROCESSES
+# A list of application processes to target for quitting. Names should match what is displayed for the process in Activity Monitor (e.g. "Chess", not "Chess.app"). If no processes need to be quit, comment these array values out.
 processNames=(
   "Box Sync"
 )
 
 
-# FILE PATHS:
-# A list of full file paths to target for launchd unload and removal.
-# Leave off trailing slashes from directory paths.
-#
-# If no files need to be manually deleted, comment these array values out.
+# FILE PATHS
+# A list of full file paths to target for launchd unload and removal. Leave off trailing slashes from directory paths. If no files need to be manually deleted, comment these array values out.
 resourceFiles=(
   "/Applications/Box Sync.app"
   "/Library/PrivilegedHelperTools/com.box.sync.bootstrapper"
@@ -89,8 +74,6 @@ quit_processes () {
     if echo "$currentProcesses" | /usr/bin/grep -q "$process"; then
       /bin/launchctl asuser "$loggedInUserUID" /usr/bin/osascript -e "tell application \"${process}\" to quit"
       echo "Quit ${process}."
-    else
-      echo "${process} not running."
     fi
   done
 }
@@ -131,8 +114,7 @@ delete_files () {
 
 
 
-# Each function will only execute if the respective source array is not empty
-# or undefined.
+# Each function will only execute if the respective source array is not empty or undefined.
 if [[ -n "${processNames[*]}" ]]; then
   echo "Quitting processes (if running)..."
   quit_processes

--- a/scripts/script-templates/uninstaller-template/Uninstall Google Santa.sh
+++ b/scripts/script-templates/uninstaller-template/Uninstall Google Santa.sh
@@ -1,0 +1,137 @@
+#!/bin/bash
+
+###
+#
+#            Name:  Uninstall Google Santa.sh
+#     Description:  A template script to assist with the uninstallation of macOS products where the vendor has missing or incomplete removal solutions. Attempts vendor uninstall by running all provided uninstallation executables, quits all running target processes, unloads all associated launchd tasks, then removes all associated files.
+#                   https://github.com/palantir/jamf-pro-scripts/tree/main/scripts/script-templates/uninstaller-template
+#         Created:  2017-10-23
+#   Last Modified:  2023-05-02
+#         Version:  1.3.10pal1
+#
+#
+# Copyright 2017 Palantir Technologies, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#
+###
+
+
+
+########## variable-ing ##########
+
+
+
+# ENVIRONMENT VARIABLES (leave as-is)
+loggedInUser=$(/usr/bin/stat -f%Su "/dev/console")
+# For any file paths used later in this script, use "$loggedInUserHome" for the current user's home folder path. Don't just assume the home folder is at /Users/${loggedInUser}.
+# shellcheck disable=SC2034
+loggedInUserHome=$(/usr/bin/dscl . -read "/Users/${loggedInUser}" NFSHomeDirectory | /usr/bin/awk '{print $NF}')
+loggedInUserUID=$(/usr/bin/id -u "$loggedInUser")
+currentProcesses=$(/bin/ps aux)
+launchAgentCheck=$(/bin/launchctl asuser "$loggedInUserUID" /bin/launchctl list)
+launchDaemonCheck=$(/bin/launchctl list)
+
+
+# PROCESSES
+# A list of application processes to target for quitting. Names should match what is displayed for the process in Activity Monitor (e.g. "Chess", not "Chess.app"). If no processes need to be quit, comment these array values out.
+processNames=(
+  "Santa"
+  "santa.ext"
+  "santabs"
+  "santad"
+)
+
+
+# FILE PATHS
+# A list of full file paths to target for launchd unload and removal. Leave off trailing slashes from directory paths. If no files need to be manually deleted, comment these array values out.
+resourceFiles=(
+  "/Applications/Santa.app"
+  "/Library/Extensions/santa-driver.kext"
+  "/Library/LaunchAgents/com.google.santagui.plist"
+  "/Library/LaunchAgents/com.google.santa.plist"
+  "/Library/LaunchDaemons/com.google.santad.plist"
+  "/Library/LaunchDaemons/com.google.santa.bundleservice.plist"
+  "/private/etc/asl/com.google.santa.asl.conf"
+  "/private/etc/newsyslog.d/com.google.santa.newsyslog.conf"
+  "/usr/local/bin/santactl"
+  "/var/db/santa"
+)
+
+
+
+########## function-ing ##########
+
+
+
+# Quits target processes.
+quit_processes () {
+  for process in "${processNames[@]}"; do
+    if echo "$currentProcesses" | /usr/bin/grep -q "$process"; then
+      /bin/launchctl asuser "$loggedInUserUID" /usr/bin/osascript -e "tell application \"${process}\" to quit"
+      echo "Quit ${process}."
+    fi
+  done
+}
+
+
+# Removes all remaining resource files.
+delete_files () {
+  for targetFile in "${resourceFiles[@]}"; do
+    # Check if file exists.
+    if [ -e "$targetFile" ]; then
+      # Check if file is a plist.
+      if echo "$targetFile" | /usr/bin/grep -q ".plist"; then
+        # If plist is loaded as LaunchAgent or LaunchDaemon, unload it.
+        justThePlist=$(/usr/bin/basename "$targetFile" | /usr/bin/awk -F.plist '{print $1}')
+        if echo "$launchAgentCheck" | /usr/bin/grep -q "$justThePlist"; then
+          /bin/launchctl asuser "$loggedInUserUID" /bin/launchctl unload "$targetFile"
+          echo "Unloaded LaunchAgent at ${targetFile}."
+        elif echo "$launchDaemonCheck" | /usr/bin/grep -q "$justThePlist"; then
+          /bin/launchctl unload "$targetFile"
+          echo "Unloaded LaunchDaemon at ${targetFile}."
+        fi
+      fi
+      # Remove system immutable flag if present.
+      if /bin/ls -ldO "$targetFile" | /usr/bin/awk '{print $5}' | /usr/bin/grep -q "schg"; then
+        /usr/bin/chflags -R noschg "$targetFile"
+        echo "Removed system immutable flag for ${targetFile}."
+      fi
+      # Remove file.
+      /bin/rm -rf "$targetFile"
+      echo "Removed ${targetFile}."
+    fi
+  done
+}
+
+
+
+########## main process ##########
+
+
+
+# Each function will only execute if the respective source array is not empty or undefined.
+if [[ -n "${processNames[*]}" ]]; then
+  echo "Quitting processes (if running)..."
+  quit_processes
+fi
+
+if [[ -n "${resourceFiles[*]}" ]]; then
+  echo "Removing files (if present)..."
+  delete_files
+fi
+
+
+
+exit 0

--- a/scripts/script-templates/uninstaller-template/Uninstall Google Santa.sh
+++ b/scripts/script-templates/uninstaller-template/Uninstall Google Santa.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# shellcheck disable=SC2034
 
 ###
 #
@@ -36,7 +37,6 @@
 # ENVIRONMENT VARIABLES (leave as-is)
 loggedInUser=$(/usr/bin/stat -f%Su "/dev/console")
 # For any file paths used later in this script, use "$loggedInUserHome" for the current user's home folder path. Don't just assume the home folder is at /Users/${loggedInUser}.
-# shellcheck disable=SC2034
 loggedInUserHome=$(/usr/bin/dscl . -read "/Users/${loggedInUser}" NFSHomeDirectory | /usr/bin/awk '{print $NF}')
 loggedInUserUID=$(/usr/bin/id -u "$loggedInUser")
 currentProcesses=$(/bin/ps aux)

--- a/scripts/script-templates/uninstaller-template/Uninstall Google Santa.sh
+++ b/scripts/script-templates/uninstaller-template/Uninstall Google Santa.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# shellcheck disable=SC2034
 
 ###
 #
@@ -37,9 +36,9 @@
 # ENVIRONMENT VARIABLES (leave as-is)
 loggedInUser=$(/usr/bin/stat -f%Su "/dev/console")
 # For any file paths used later in this script, use "$loggedInUserHome" for the current user's home folder path. Don't just assume the home folder is at /Users/${loggedInUser}.
+# shellcheck disable=SC2034
 loggedInUserHome=$(/usr/bin/dscl . -read "/Users/${loggedInUser}" NFSHomeDirectory | /usr/bin/awk '{print $NF}')
 loggedInUserUID=$(/usr/bin/id -u "$loggedInUser")
-currentProcesses=$(/bin/ps aux)
 launchAgentCheck=$(/bin/launchctl asuser "$loggedInUserUID" /bin/launchctl list)
 launchDaemonCheck=$(/bin/launchctl list)
 
@@ -77,6 +76,7 @@ resourceFiles=(
 
 # Quits target processes.
 quit_processes () {
+  currentProcesses=$(/bin/ps aux)
   for process in "${processNames[@]}"; do
     if echo "$currentProcesses" | /usr/bin/grep -q "$process"; then
       /bin/launchctl asuser "$loggedInUserUID" /usr/bin/osascript -e "tell application \"${process}\" to quit"

--- a/scripts/script-templates/uninstaller-template/Uninstall Osquery.sh
+++ b/scripts/script-templates/uninstaller-template/Uninstall Osquery.sh
@@ -3,17 +3,11 @@
 ###
 #
 #            Name:  Uninstall Osquery.sh
-#     Description:  A template script to assist with the uninstallation of
-#                   macOS products where the vendor has missing or incomplete
-#                   removal solutions.
-#                   Attempts vendor uninstall by running all provided
-#                   uninstallation executables, quits all running target
-#                   processes, unloads all associated launchd tasks, then
-#                   removes all associated files.
+#     Description:  A template script to assist with the uninstallation of macOS products where the vendor has missing or incomplete removal solutions. Attempts vendor uninstall by running all provided uninstallation executables, quits all running target processes, unloads all associated launchd tasks, then removes all associated files.
 #                   https://github.com/palantir/jamf-pro-scripts/tree/main/scripts/script-templates/uninstaller-template
 #         Created:  2017-10-23
-#   Last Modified:  2023-03-14
-#         Version:  1.3.9pal3
+#   Last Modified:  2023-05-02
+#         Version:  1.3.10pal1
 #
 #
 # Copyright 2017 Palantir Technologies, Inc.
@@ -39,11 +33,9 @@
 
 
 
-# ENVIRONMENT VARIABLES (leave as-is):
+# ENVIRONMENT VARIABLES (leave as-is)
 loggedInUser=$(/usr/bin/stat -f%Su "/dev/console")
-# For any file paths used later in this script, use "$loggedInUserHome" for the
-# current user's home folder path. Don't just assume the home folder is at
-# /Users/$loggedInUser.
+# For any file paths used later in this script, use "$loggedInUserHome" for the current user's home folder path. Don't just assume the home folder is at /Users/${loggedInUser}.
 # shellcheck disable=SC2034
 loggedInUserHome=$(/usr/bin/dscl . -read "/Users/${loggedInUser}" NFSHomeDirectory | /usr/bin/awk '{print $NF}')
 loggedInUserUID=$(/usr/bin/id -u "$loggedInUser")
@@ -52,12 +44,8 @@ launchAgentCheck=$(/bin/launchctl asuser "$loggedInUserUID" /bin/launchctl list)
 launchDaemonCheck=$(/bin/launchctl list)
 
 
-# PROCESSES:
-# A list of application processes to target for quitting.
-# Names should match what is displayed for the process in Activity Monitor
-# (e.g. "Chess", not "Chess.app").
-#
-# If no processes need to be quit, comment these array values out.
+# PROCESSES
+# A list of application processes to target for quitting. Names should match what is displayed for the process in Activity Monitor (e.g. "Chess", not "Chess.app"). If no processes need to be quit, comment these array values out.
 processNames=(
   "osqueryctl"
   "osqueryd"
@@ -65,11 +53,8 @@ processNames=(
 )
 
 
-# FILE PATHS:
-# A list of full file paths to target for launchd unload and removal.
-# Leave off trailing slashes from directory paths.
-#
-# If no files need to be manually deleted, comment these array values out.
+# FILE PATHS
+# A list of full file paths to target for launchd unload and removal. Leave off trailing slashes from directory paths. If no files need to be manually deleted, comment these array values out.
 resourceFiles=(
   "/Library/LaunchDaemons/com.facebook.osqueryd.plist"
   "/Library/LaunchDaemons/io.osquery.agent.plist"
@@ -94,8 +79,6 @@ quit_processes () {
     if echo "$currentProcesses" | /usr/bin/grep -q "$process"; then
       /bin/launchctl asuser "$loggedInUserUID" /usr/bin/osascript -e "tell application \"${process}\" to quit"
       echo "Quit ${process}."
-    else
-      echo "${process} not running."
     fi
   done
 }
@@ -136,8 +119,7 @@ delete_files () {
 
 
 
-# Each function will only execute if the respective source array is not empty
-# or undefined.
+# Each function will only execute if the respective source array is not empty or undefined.
 if [[ -n "${processNames[*]}" ]]; then
   echo "Quitting processes (if running)..."
   quit_processes

--- a/scripts/script-templates/uninstaller-template/Uninstall Osquery.sh
+++ b/scripts/script-templates/uninstaller-template/Uninstall Osquery.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# shellcheck disable=SC2034
 
 ###
 #
@@ -36,7 +37,6 @@
 # ENVIRONMENT VARIABLES (leave as-is)
 loggedInUser=$(/usr/bin/stat -f%Su "/dev/console")
 # For any file paths used later in this script, use "$loggedInUserHome" for the current user's home folder path. Don't just assume the home folder is at /Users/${loggedInUser}.
-# shellcheck disable=SC2034
 loggedInUserHome=$(/usr/bin/dscl . -read "/Users/${loggedInUser}" NFSHomeDirectory | /usr/bin/awk '{print $NF}')
 loggedInUserUID=$(/usr/bin/id -u "$loggedInUser")
 currentProcesses=$(/bin/ps aux)

--- a/scripts/script-templates/uninstaller-template/Uninstall Osquery.sh
+++ b/scripts/script-templates/uninstaller-template/Uninstall Osquery.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# shellcheck disable=SC2034
 
 ###
 #
@@ -37,9 +36,9 @@
 # ENVIRONMENT VARIABLES (leave as-is)
 loggedInUser=$(/usr/bin/stat -f%Su "/dev/console")
 # For any file paths used later in this script, use "$loggedInUserHome" for the current user's home folder path. Don't just assume the home folder is at /Users/${loggedInUser}.
+# shellcheck disable=SC2034
 loggedInUserHome=$(/usr/bin/dscl . -read "/Users/${loggedInUser}" NFSHomeDirectory | /usr/bin/awk '{print $NF}')
 loggedInUserUID=$(/usr/bin/id -u "$loggedInUser")
-currentProcesses=$(/bin/ps aux)
 launchAgentCheck=$(/bin/launchctl asuser "$loggedInUserUID" /bin/launchctl list)
 launchDaemonCheck=$(/bin/launchctl list)
 
@@ -75,6 +74,7 @@ resourceFiles=(
 
 # Quits target processes.
 quit_processes () {
+  currentProcesses=$(/bin/ps aux)
   for process in "${processNames[@]}"; do
     if echo "$currentProcesses" | /usr/bin/grep -q "$process"; then
       /bin/launchctl asuser "$loggedInUserUID" /usr/bin/osascript -e "tell application \"${process}\" to quit"

--- a/scripts/script-templates/uninstaller-template/Uninstall Pulse Secure.sh
+++ b/scripts/script-templates/uninstaller-template/Uninstall Pulse Secure.sh
@@ -3,17 +3,11 @@
 ###
 #
 #            Name:  Uninstall Pulse Secure.sh
-#     Description:  A template script to assist with the uninstallation of
-#                   macOS products where the vendor has missing or incomplete
-#                   removal solutions.
-#                   Attempts vendor uninstall by running all provided
-#                   uninstallation executables, quits all running target
-#                   processes, unloads all associated launchd tasks, then
-#                   removes all associated files.
+#     Description:  A template script to assist with the uninstallation of macOS products where the vendor has missing or incomplete removal solutions. Attempts vendor uninstall by running all provided uninstallation executables, quits all running target processes, unloads all associated launchd tasks, then removes all associated files.
 #                   https://github.com/palantir/jamf-pro-scripts/tree/main/scripts/script-templates/uninstaller-template
 #         Created:  2017-10-23
-#   Last Modified:  2022-06-03
-#         Version:  1.3.9pal1
+#   Last Modified:  2023-05-02
+#         Version:  1.3.10pal1
 #
 #
 # Copyright 2017 Palantir Technologies, Inc.
@@ -39,11 +33,9 @@
 
 
 
-# ENVIRONMENT VARIABLES (leave as-is):
+# ENVIRONMENT VARIABLES (leave as-is)
 loggedInUser=$(/usr/bin/stat -f%Su "/dev/console")
-# For any file paths used later in this script, use "$loggedInUserHome" for the
-# current user's home folder path. Don't just assume the home folder is at
-# /Users/$loggedInUser.
+# For any file paths used later in this script, use "$loggedInUserHome" for the current user's home folder path. Don't just assume the home folder is at /Users/${loggedInUser}.
 # shellcheck disable=SC2034
 loggedInUserHome=$(/usr/bin/dscl . -read "/Users/${loggedInUser}" NFSHomeDirectory | /usr/bin/awk '{print $NF}')
 loggedInUserUID=$(/usr/bin/id -u "$loggedInUser")
@@ -52,7 +44,7 @@ launchAgentCheck=$(/bin/launchctl asuser "$loggedInUserUID" /bin/launchctl list)
 launchDaemonCheck=$(/bin/launchctl list)
 
 
-# VENDOR UNINSTALLERS:
+# VENDOR UNINSTALLERS
 # A list of file paths for vendor-provided uninstallation tools.
 # Note that vendor uninstaller workflows may differ greatly. Some vendors may
 # use their own command-line tools with custom flags or other workflows to
@@ -68,23 +60,16 @@ vendorUninstallers=(
 )
 
 
-# PROCESSES:
-# A list of application processes to target for quitting.
-# Names should match what is displayed for the process in Activity Monitor
-# (e.g. "Chess", not "Chess.app").
-#
-# If no processes need to be quit, comment these array values out.
+# PROCESSES
+# A list of application processes to target for quitting. Names should match what is displayed for the process in Activity Monitor (e.g. "Chess", not "Chess.app"). If no processes need to be quit, comment these array values out.
 processNames=(
   "Junos Pulse"
   "Pulse Secure"
 )
 
 
-# FILE PATHS:
-# A list of full file paths to target for launchd unload and removal.
-# Leave off trailing slashes from directory paths.
-#
-# If no files need to be manually deleted, comment these array values out.
+# FILE PATHS
+# A list of full file paths to target for launchd unload and removal. Leave off trailing slashes from directory paths. If no files need to be manually deleted, comment these array values out.
 resourceFiles=(
   "/Applications/Junos Pulse.app"
   "/Applications/Pulse Secure.app"
@@ -119,8 +104,6 @@ quit_processes () {
     if echo "$currentProcesses" | /usr/bin/grep -q "$process"; then
       /bin/launchctl asuser "$loggedInUserUID" /usr/bin/osascript -e "tell application \"${process}\" to quit"
       echo "Quit ${process}."
-    else
-      echo "${process} not running."
     fi
   done
 }
@@ -161,8 +144,7 @@ delete_files () {
 
 
 
-# Each function will only execute if the respective source array is not empty
-# or undefined.
+# Each function will only execute if the respective source array is not empty or undefined.
 if [[ -n "${vendorUninstallers[*]}" ]]; then
   echo "Running vendor uninstallers..."
   run_vendor_uninstallers

--- a/scripts/script-templates/uninstaller-template/Uninstall Pulse Secure.sh
+++ b/scripts/script-templates/uninstaller-template/Uninstall Pulse Secure.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# shellcheck disable=SC2034
 
 ###
 #
@@ -37,9 +36,9 @@
 # ENVIRONMENT VARIABLES (leave as-is)
 loggedInUser=$(/usr/bin/stat -f%Su "/dev/console")
 # For any file paths used later in this script, use "$loggedInUserHome" for the current user's home folder path. Don't just assume the home folder is at /Users/${loggedInUser}.
+# shellcheck disable=SC2034
 loggedInUserHome=$(/usr/bin/dscl . -read "/Users/${loggedInUser}" NFSHomeDirectory | /usr/bin/awk '{print $NF}')
 loggedInUserUID=$(/usr/bin/id -u "$loggedInUser")
-currentProcesses=$(/bin/ps aux)
 launchAgentCheck=$(/bin/launchctl asuser "$loggedInUserUID" /bin/launchctl list)
 launchDaemonCheck=$(/bin/launchctl list)
 
@@ -100,6 +99,7 @@ run_vendor_uninstallers () {
 
 # Quits target processes.
 quit_processes () {
+  currentProcesses=$(/bin/ps aux)
   for process in "${processNames[@]}"; do
     if echo "$currentProcesses" | /usr/bin/grep -q "$process"; then
       /bin/launchctl asuser "$loggedInUserUID" /usr/bin/osascript -e "tell application \"${process}\" to quit"

--- a/scripts/script-templates/uninstaller-template/Uninstall Pulse Secure.sh
+++ b/scripts/script-templates/uninstaller-template/Uninstall Pulse Secure.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# shellcheck disable=SC2034
 
 ###
 #
@@ -36,7 +37,6 @@
 # ENVIRONMENT VARIABLES (leave as-is)
 loggedInUser=$(/usr/bin/stat -f%Su "/dev/console")
 # For any file paths used later in this script, use "$loggedInUserHome" for the current user's home folder path. Don't just assume the home folder is at /Users/${loggedInUser}.
-# shellcheck disable=SC2034
 loggedInUserHome=$(/usr/bin/dscl . -read "/Users/${loggedInUser}" NFSHomeDirectory | /usr/bin/awk '{print $NF}')
 loggedInUserUID=$(/usr/bin/id -u "$loggedInUser")
 currentProcesses=$(/bin/ps aux)

--- a/scripts/script-templates/uninstaller-template/Uninstall Silverlight.sh
+++ b/scripts/script-templates/uninstaller-template/Uninstall Silverlight.sh
@@ -3,17 +3,11 @@
 ###
 #
 #            Name:  Uninstall Silverlight.sh
-#     Description:  A template script to assist with the uninstallation of
-#                   macOS products where the vendor has missing or incomplete
-#                   removal solutions.
-#                   Attempts vendor uninstall by running all provided
-#                   uninstallation executables, quits all running target
-#                   processes, unloads all associated launchd tasks, then
-#                   removes all associated files.
+#     Description:  A template script to assist with the uninstallation of macOS products where the vendor has missing or incomplete removal solutions. Attempts vendor uninstall by running all provided uninstallation executables, quits all running target processes, unloads all associated launchd tasks, then removes all associated files.
 #                   https://github.com/palantir/jamf-pro-scripts/tree/main/scripts/script-templates/uninstaller-template
 #         Created:  2017-10-23
-#   Last Modified:  2022-06-03
-#         Version:  1.3.9pal1
+#   Last Modified:  2023-05-02
+#         Version:  1.3.10pal1
 #
 #
 # Copyright 2017 Palantir Technologies, Inc.
@@ -39,11 +33,9 @@
 
 
 
-# ENVIRONMENT VARIABLES (leave as-is):
+# ENVIRONMENT VARIABLES (leave as-is)
 loggedInUser=$(/usr/bin/stat -f%Su "/dev/console")
-# For any file paths used later in this script, use "$loggedInUserHome" for the
-# current user's home folder path. Don't just assume the home folder is at
-# /Users/$loggedInUser.
+# For any file paths used later in this script, use "$loggedInUserHome" for the current user's home folder path. Don't just assume the home folder is at /Users/${loggedInUser}.
 # shellcheck disable=SC2034
 loggedInUserHome=$(/usr/bin/dscl . -read "/Users/${loggedInUser}" NFSHomeDirectory | /usr/bin/awk '{print $NF}')
 loggedInUserUID=$(/usr/bin/id -u "$loggedInUser")
@@ -51,11 +43,8 @@ launchAgentCheck=$(/bin/launchctl asuser "$loggedInUserUID" /bin/launchctl list)
 launchDaemonCheck=$(/bin/launchctl list)
 
 
-# FILE PATHS:
-# A list of full file paths to target for launchd unload and removal.
-# Leave off trailing slashes from directory paths.
-#
-# If no files need to be manually deleted, comment these array values out.
+# FILE PATHS
+# A list of full file paths to target for launchd unload and removal. Leave off trailing slashes from directory paths. If no files need to be manually deleted, comment these array values out.
 resourceFiles=(
   "/Library/Internet Plug-Ins/Silverlight.plugin"
   "/Library/Internet Plug-Ins/WPFe.plugin"
@@ -105,8 +94,7 @@ delete_files () {
 
 
 
-# Each function will only execute if the respective source array is not empty
-# or undefined.
+# Each function will only execute if the respective source array is not empty or undefined.
 if [[ -n "${resourceFiles[*]}" ]]; then
   echo "Removing files (if present)..."
   delete_files

--- a/scripts/script-templates/uninstaller-template/Uninstall Silverlight.sh
+++ b/scripts/script-templates/uninstaller-template/Uninstall Silverlight.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# shellcheck disable=SC2034
 
 ###
 #
@@ -37,9 +36,9 @@
 # ENVIRONMENT VARIABLES (leave as-is)
 loggedInUser=$(/usr/bin/stat -f%Su "/dev/console")
 # For any file paths used later in this script, use "$loggedInUserHome" for the current user's home folder path. Don't just assume the home folder is at /Users/${loggedInUser}.
+# shellcheck disable=SC2034
 loggedInUserHome=$(/usr/bin/dscl . -read "/Users/${loggedInUser}" NFSHomeDirectory | /usr/bin/awk '{print $NF}')
 loggedInUserUID=$(/usr/bin/id -u "$loggedInUser")
-currentProcesses=$(/bin/ps aux)
 launchAgentCheck=$(/bin/launchctl asuser "$loggedInUserUID" /bin/launchctl list)
 launchDaemonCheck=$(/bin/launchctl list)
 

--- a/scripts/script-templates/uninstaller-template/Uninstall Silverlight.sh
+++ b/scripts/script-templates/uninstaller-template/Uninstall Silverlight.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# shellcheck disable=SC2034
 
 ###
 #
@@ -36,9 +37,9 @@
 # ENVIRONMENT VARIABLES (leave as-is)
 loggedInUser=$(/usr/bin/stat -f%Su "/dev/console")
 # For any file paths used later in this script, use "$loggedInUserHome" for the current user's home folder path. Don't just assume the home folder is at /Users/${loggedInUser}.
-# shellcheck disable=SC2034
 loggedInUserHome=$(/usr/bin/dscl . -read "/Users/${loggedInUser}" NFSHomeDirectory | /usr/bin/awk '{print $NF}')
 loggedInUserUID=$(/usr/bin/id -u "$loggedInUser")
+currentProcesses=$(/bin/ps aux)
 launchAgentCheck=$(/bin/launchctl asuser "$loggedInUserUID" /bin/launchctl list)
 launchDaemonCheck=$(/bin/launchctl list)
 

--- a/scripts/script-templates/uninstaller-template/Uninstall Single Application.sh
+++ b/scripts/script-templates/uninstaller-template/Uninstall Single Application.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# shellcheck disable=SC2034
 
 ###
 #
@@ -36,7 +37,6 @@
 # ENVIRONMENT VARIABLES (leave as-is)
 loggedInUser=$(/usr/bin/stat -f%Su "/dev/console")
 # For any file paths used later in this script, use "$loggedInUserHome" for the current user's home folder path. Don't just assume the home folder is at /Users/${loggedInUser}.
-# shellcheck disable=SC2034
 loggedInUserHome=$(/usr/bin/dscl . -read "/Users/${loggedInUser}" NFSHomeDirectory | /usr/bin/awk '{print $NF}')
 loggedInUserUID=$(/usr/bin/id -u "$loggedInUser")
 currentProcesses=$(/bin/ps aux)

--- a/scripts/script-templates/uninstaller-template/Uninstall Single Application.sh
+++ b/scripts/script-templates/uninstaller-template/Uninstall Single Application.sh
@@ -3,17 +3,11 @@
 ###
 #
 #            Name:  Uninstall Single Application.sh
-#     Description:  A template script to assist with the uninstallation of
-#                   macOS products where the vendor has missing or incomplete
-#                   removal solutions.
-#                   Attempts vendor uninstall by running all provided
-#                   uninstallation executables, quits all running target
-#                   processes, unloads all associated launchd tasks, then
-#                   removes all associated files.
+#     Description:  A template script to assist with the uninstallation of macOS products where the vendor has missing or incomplete removal solutions. Attempts vendor uninstall by running all provided uninstallation executables, quits all running target processes, unloads all associated launchd tasks, then removes all associated files.
 #                   https://github.com/palantir/jamf-pro-scripts/tree/main/scripts/script-templates/uninstaller-template
 #         Created:  2017-10-23
-#   Last Modified:  2022-06-21
-#         Version:  1.3.9pal2
+#   Last Modified:  2023-05-02
+#         Version:  1.3.10pal1
 #
 #
 # Copyright 2017 Palantir Technologies, Inc.
@@ -39,11 +33,9 @@
 
 
 
-# ENVIRONMENT VARIABLES (leave as-is):
+# ENVIRONMENT VARIABLES (leave as-is)
 loggedInUser=$(/usr/bin/stat -f%Su "/dev/console")
-# For any file paths used later in this script, use "$loggedInUserHome" for the
-# current user's home folder path. Don't just assume the home folder is at
-# /Users/$loggedInUser.
+# For any file paths used later in this script, use "$loggedInUserHome" for the current user's home folder path. Don't just assume the home folder is at /Users/${loggedInUser}.
 # shellcheck disable=SC2034
 loggedInUserHome=$(/usr/bin/dscl . -read "/Users/${loggedInUser}" NFSHomeDirectory | /usr/bin/awk '{print $NF}')
 loggedInUserUID=$(/usr/bin/id -u "$loggedInUser")
@@ -52,20 +44,13 @@ launchAgentCheck=$(/bin/launchctl asuser "$loggedInUserUID" /bin/launchctl list)
 launchDaemonCheck=$(/bin/launchctl list)
 
 
-# PROCESSES:
-# A list of application processes to target for quitting.
-# Names should match what is displayed for the process in Activity Monitor
-# (e.g. "Chess", not "Chess.app").
-#
-# If no processes need to be quit, comment these array values out.
+# PROCESSES
+# A list of application processes to target for quitting. Names should match what is displayed for the process in Activity Monitor (e.g. "Chess", not "Chess.app"). If no processes need to be quit, comment these array values out.
 process="${4}" # Jamf Pro script parameter: "App Process"
 
 
-# FILE PATHS:
-# A list of full file paths to target for launchd unload and removal.
-# Leave off trailing slashes from directory paths.
-#
-# If no files need to be manually deleted, comment these array values out.
+# FILE PATHS
+# A list of full file paths to target for launchd unload and removal. Leave off trailing slashes from directory paths. If no files need to be manually deleted, comment these array values out.
 targetFile="${5}" # Jamf Pro script parameter: "App File Path"; should be full path to the application, e.g. "/System/Applications/Chess.app"
 
 
@@ -83,13 +68,11 @@ check_jamf_pro_arguments () {
 }
 
 
-# Quit target processes and remove associated login items.
+# Quit target processes.
 quit_processes () {
   if echo "$currentProcesses" | /usr/bin/grep -q "$process"; then
     /bin/launchctl asuser "$loggedInUserUID" /usr/bin/osascript -e "tell application \"${process}\" to quit"
     echo "Quit ${process}."
-  else
-    echo "${process} not running."
   fi
 }
 
@@ -131,8 +114,7 @@ delete_files () {
 check_jamf_pro_arguments
 
 
-# Each function will only execute if the respective source array is not empty
-# or undefined.
+# Each function will only execute if the respective source array is not empty or undefined.
 if [ -n "${process}" ]; then
   echo "Quitting process (if running)..."
   quit_processes

--- a/scripts/script-templates/uninstaller-template/Uninstall Single Application.sh
+++ b/scripts/script-templates/uninstaller-template/Uninstall Single Application.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# shellcheck disable=SC2034
 
 ###
 #
@@ -37,9 +36,9 @@
 # ENVIRONMENT VARIABLES (leave as-is)
 loggedInUser=$(/usr/bin/stat -f%Su "/dev/console")
 # For any file paths used later in this script, use "$loggedInUserHome" for the current user's home folder path. Don't just assume the home folder is at /Users/${loggedInUser}.
+# shellcheck disable=SC2034
 loggedInUserHome=$(/usr/bin/dscl . -read "/Users/${loggedInUser}" NFSHomeDirectory | /usr/bin/awk '{print $NF}')
 loggedInUserUID=$(/usr/bin/id -u "$loggedInUser")
-currentProcesses=$(/bin/ps aux)
 launchAgentCheck=$(/bin/launchctl asuser "$loggedInUserUID" /bin/launchctl list)
 launchDaemonCheck=$(/bin/launchctl list)
 
@@ -70,6 +69,7 @@ check_jamf_pro_arguments () {
 
 # Quit target processes.
 quit_processes () {
+  currentProcesses=$(/bin/ps aux)
   if echo "$currentProcesses" | /usr/bin/grep -q "$process"; then
     /bin/launchctl asuser "$loggedInUserUID" /usr/bin/osascript -e "tell application \"${process}\" to quit"
     echo "Quit ${process}."

--- a/scripts/script-templates/uninstaller-template/uninstaller-template.sh
+++ b/scripts/script-templates/uninstaller-template/uninstaller-template.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# shellcheck disable=SC2034
 
 ###
 #
@@ -36,7 +37,6 @@
 # ENVIRONMENT VARIABLES (leave as-is)
 loggedInUser=$(/usr/bin/stat -f%Su "/dev/console")
 # For any file paths used later in this script, use "$loggedInUserHome" for the current user's home folder path. Don't just assume the home folder is at /Users/${loggedInUser}.
-# shellcheck disable=SC2034
 loggedInUserHome=$(/usr/bin/dscl . -read "/Users/${loggedInUser}" NFSHomeDirectory | /usr/bin/awk '{print $NF}')
 loggedInUserUID=$(/usr/bin/id -u "$loggedInUser")
 currentProcesses=$(/bin/ps aux)

--- a/scripts/script-templates/uninstaller-template/uninstaller-template.sh
+++ b/scripts/script-templates/uninstaller-template/uninstaller-template.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# shellcheck disable=SC2034
 
 ###
 #
@@ -37,9 +36,9 @@
 # ENVIRONMENT VARIABLES (leave as-is)
 loggedInUser=$(/usr/bin/stat -f%Su "/dev/console")
 # For any file paths used later in this script, use "$loggedInUserHome" for the current user's home folder path. Don't just assume the home folder is at /Users/${loggedInUser}.
+# shellcheck disable=SC2034
 loggedInUserHome=$(/usr/bin/dscl . -read "/Users/${loggedInUser}" NFSHomeDirectory | /usr/bin/awk '{print $NF}')
 loggedInUserUID=$(/usr/bin/id -u "$loggedInUser")
-currentProcesses=$(/bin/ps aux)
 launchAgentCheck=$(/bin/launchctl asuser "$loggedInUserUID" /bin/launchctl list)
 launchDaemonCheck=$(/bin/launchctl list)
 
@@ -87,6 +86,7 @@ run_vendor_uninstallers () {
 
 # Quits target processes.
 quit_processes () {
+  currentProcesses=$(/bin/ps aux)
   for process in "${processNames[@]}"; do
     if echo "$currentProcesses" | /usr/bin/grep -q "$process"; then
       /bin/launchctl asuser "$loggedInUserUID" /usr/bin/osascript -e "tell application \"${process}\" to quit"

--- a/scripts/script-templates/uninstaller-template/uninstaller-template.sh
+++ b/scripts/script-templates/uninstaller-template/uninstaller-template.sh
@@ -3,17 +3,11 @@
 ###
 #
 #            Name:  uninstaller-template.sh
-#     Description:  A template script to assist with the uninstallation of
-#                   macOS products where the vendor has missing or incomplete
-#                   removal solutions.
-#                   Attempts vendor uninstall by running all provided
-#                   uninstallation executables, quits all running target
-#                   processes, unloads all associated launchd tasks, then
-#                   removes all associated files.
+#     Description:  A template script to assist with the uninstallation of macOS products where the vendor has missing or incomplete removal solutions. Attempts vendor uninstall by running all provided uninstallation executables, quits all running target processes, unloads all associated launchd tasks, then removes all associated files.
 #                   https://github.com/palantir/jamf-pro-scripts/tree/main/scripts/script-templates/uninstaller-template
 #         Created:  2017-10-23
-#   Last Modified:  2022-06-03
-#         Version:  1.3.9
+#   Last Modified:  2023-05-02
+#         Version:  1.3.10
 #
 #
 # Copyright 2017 Palantir Technologies, Inc.
@@ -39,11 +33,9 @@
 
 
 
-# ENVIRONMENT VARIABLES (leave as-is):
+# ENVIRONMENT VARIABLES (leave as-is)
 loggedInUser=$(/usr/bin/stat -f%Su "/dev/console")
-# For any file paths used later in this script, use "$loggedInUserHome" for the
-# current user's home folder path. Don't just assume the home folder is at
-# /Users/$loggedInUser.
+# For any file paths used later in this script, use "$loggedInUserHome" for the current user's home folder path. Don't just assume the home folder is at /Users/${loggedInUser}.
 # shellcheck disable=SC2034
 loggedInUserHome=$(/usr/bin/dscl . -read "/Users/${loggedInUser}" NFSHomeDirectory | /usr/bin/awk '{print $NF}')
 loggedInUserUID=$(/usr/bin/id -u "$loggedInUser")
@@ -52,39 +44,24 @@ launchAgentCheck=$(/bin/launchctl asuser "$loggedInUserUID" /bin/launchctl list)
 launchDaemonCheck=$(/bin/launchctl list)
 
 
-# VENDOR UNINSTALLERS:
-# A list of file paths for vendor-provided uninstallation tools.
-# Note that vendor uninstaller workflows may differ greatly. Some vendors may
-# use their own command-line tools with custom flags or other workflows to
-# accomplish this task (that's why this script exists!), so make any necessary
-# changes to the below commands if the uninstallation workflow isn't simply
-# calling executable files.
-#
-# If the vendor did not provide an uninstaller workflow, comment these array
-# values out.
+# VENDOR UNINSTALLERS
+# A list of file paths for vendor-provided uninstallation tools. Note that vendor uninstaller workflows may differ greatly. Some vendors may use their own command-line tools with custom flags or other workflows to accomplish this task (that's why this script exists!), so make any necessary changes to the below commands if the uninstallation workflow isn't simply calling executable files. If the vendor did not provide an uninstaller workflow, comment these array values out.
 vendorUninstallers=(
   "/path/to/vendor_uninstaller_command1.sh"
   "/path/to/vendor_uninstaller_command2.sh"
 )
 
 
-# PROCESSES:
-# A list of application processes to target for quitting.
-# Names should match what is displayed for the process in Activity Monitor
-# (e.g. "Chess", not "Chess.app").
-#
-# If no processes need to be quit, comment these array values out.
+# PROCESSES
+# A list of application processes to target for quitting. Names should match what is displayed for the process in Activity Monitor (e.g. "Chess", not "Chess.app"). If no processes need to be quit, comment these array values out.
 processNames=(
   "Process Name 1"
   "Process Name 2"
 )
 
 
-# FILE PATHS:
-# A list of full file paths to target for launchd unload and removal.
-# Leave off trailing slashes from directory paths.
-#
-# If no files need to be manually deleted, comment these array values out.
+# FILE PATHS
+# A list of full file paths to target for launchd unload and removal. Leave off trailing slashes from directory paths. If no files need to be manually deleted, comment these array values out.
 resourceFiles=(
   "/path/to/file1"
   "/path/to/file2"
@@ -114,8 +91,6 @@ quit_processes () {
     if echo "$currentProcesses" | /usr/bin/grep -q "$process"; then
       /bin/launchctl asuser "$loggedInUserUID" /usr/bin/osascript -e "tell application \"${process}\" to quit"
       echo "Quit ${process}."
-    else
-      echo "${process} not running."
     fi
   done
 }
@@ -156,8 +131,7 @@ delete_files () {
 
 
 
-# Each function will only execute if the respective source array is not empty
-# or undefined.
+# Each function will only execute if the respective source array is not empty or undefined.
 if [[ -n "${vendorUninstallers[*]}" ]]; then
   echo "Running vendor uninstallers..."
   run_vendor_uninstallers


### PR DESCRIPTION
- uninstaller-template.sh updates
  - removed echo output when specified process is not running to reduce log noise
  - moved $currentProcesses definition to quit_processes array so it can be removed en masse when unneeded in child scripts
  - consolidated comment paragraphs to single lines
- updated example uninstallers with changes from template
- added more uninstallers
- fixed syntax error in Firmware Password Set.sh