### PR TITLE
converted uninstaller-template.sh to POSIX Shell

### DIFF
--- a/scripts/script-templates/uninstaller-template/README.md
+++ b/scripts/script-templates/uninstaller-template/README.md
@@ -9,7 +9,7 @@
 Given a list of vendor uninstaller commands and paths, process names, and/or file paths for deletion (all of these are optional), this script does the following:
 
 1. Runs vendor uninstaller commands
-2. Quits target processes and removes them from login items
+2. Quits target processes
 3. Unloads LaunchAgents and LaunchDaemons
 4. Removes the system-immutable flag for locked files
 5. Deletes all targeted files and folders
@@ -17,15 +17,15 @@ Given a list of vendor uninstaller commands and paths, process names, and/or fil
 ## How do I set it up?
 
 1. Make a copy of `uninstaller-template.sh` and rename it to reflect the product you're uninstalling (e.g. `Uninstall Chess.sh`).
-2. Update the `vendorUninstallerCommands`, `processNames`, and `resourceFiles` arrays to list all respective uninstall commands (with any required arguments), process names, and file paths as instructed in script comments.
+2. Update the `run_vendor_uninstaller`, `quit_process`, and `delete_file` function runs at the bottom of the script (in the `main process` section) to run on each respective uninstall command, process name, and file path as instructed in script comments. If multiple such objects need to be acted upon, add an additional function run for each such item.
 
-  If you don't need to perform any particular script function (`run_vendor_uninstallers`, `quit_processes`, `delete_files`), just leave the corresponding array values blank (or comment the lines out) and the script will skip those steps.
+  If you don't need to perform any particular script function (`run_vendor_uninstallers`, `quit_processes`, `delete_files`), you can comment out or delete the example lines running those functions, and the script will skip those steps.
 
-3. Update your script copy's Version and Last Modified attributes. You should keep the template script version and append a substring unique to your environment (example scripts in this repo are appended with `pal#`). Whenever you modify your script but retain the same content from the template script, iterate your substring, and whenever you update your script with changes from the template, iterate the main version. This will allow you to tell if your script is out of date from template changes or if you have made multiple modifications to your custom build.
+3. Update your script copy's Version and Last Modified attributes. You should keep the template script version and append a substring unique to your environment (example scripts in this repo are appended with `pal#`, e.g. `2.0pal1`). Whenever you modify your script but retain the same content from the template script, iterate your substring (e.g. `2.0pal2`), and whenever you update your script with changes from the template, iterate the main version and revert the substring version (e.g. `2.1pal1`). This will allow you to tell if your script is out of date from template changes or if you have made multiple modifications to your custom build.
 
 ## What if I just have one file to delete and one process to kill? (e.g. Mac App Store installs)
 
-Use `Uninstall Single Application.sh`! It matches the template workflow but lets you define one process and one file path to target for uninstallation via Jamf Pro policy script argument. This allows reuse of a single script for multiple app uninstallation policies.
+Use `Uninstall Single Application.sh`! It matches the template workflow but lets you define one process and one file path to target for uninstallation via Jamf Pro policy script arguments. This allows reuse of a single script for multiple app uninstallation policies.
 
 ## License
 This project is made available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0).

--- a/scripts/script-templates/uninstaller-template/Uninstall Adobe AIR.sh
+++ b/scripts/script-templates/uninstaller-template/Uninstall Adobe AIR.sh
@@ -1,13 +1,13 @@
-#!/bin/bash
+#!/bin/sh
 
 ###
 #
 #            Name:  Uninstall Adobe AIR.sh
-#     Description:  A template script to assist with the uninstallation of macOS products where the vendor has missing or incomplete removal solutions. Attempts vendor uninstall by running all provided uninstallation executables, quits all running target processes, unloads all associated launchd tasks, then removes all associated files.
+#     Description:  A template script to assist with the uninstallation of macOS products where the vendor has missing or incomplete removal solutions. Attempts vendor uninstall by running all provided uninstallation executables, quits all running target processes, then removes all associated target files.
 #                   https://github.com/palantir/jamf-pro-scripts/tree/main/scripts/script-templates/uninstaller-template
 #         Created:  2017-10-23
-#   Last Modified:  2023-05-02
-#         Version:  1.3.10pal1
+#   Last Modified:  2023-07-17
+#         Version:  2.0pal1
 #
 #
 # Copyright 2017 Palantir Technologies, Inc.
@@ -33,39 +33,11 @@
 
 
 
-# ENVIRONMENT VARIABLES (leave as-is)
 loggedInUser=$(/usr/bin/stat -f%Su "/dev/console")
+loggedInUserUID=$(/usr/bin/id -u "$loggedInUser")
 # For any file paths used later in this script, use "$loggedInUserHome" for the current user's home folder path. Don't just assume the home folder is at /Users/${loggedInUser}.
 # shellcheck disable=SC2034
 loggedInUserHome=$(/usr/bin/dscl . -read "/Users/${loggedInUser}" NFSHomeDirectory | /usr/bin/awk '{print $NF}')
-loggedInUserUID=$(/usr/bin/id -u "$loggedInUser")
-launchAgentCheck=$(/bin/launchctl asuser "$loggedInUserUID" /bin/launchctl list)
-launchDaemonCheck=$(/bin/launchctl list)
-
-
-# VENDOR UNINSTALLERS
-# A list of file paths for vendor-provided uninstallation tools. Note that vendor uninstaller workflows may differ greatly. Some vendors may use their own command-line tools with custom flags or other workflows to accomplish this task (that's why this script exists!), so make any necessary changes to the below commands if the uninstallation workflow isn't simply calling executable files. If the vendor did not provide an uninstaller workflow, comment these array values out.
-vendorUninstallers=(
-  "/Applications/Utilities/Adobe AIR Uninstaller.app/Contents/MacOS/Adobe AIR Installer"
-)
-
-
-# PROCESSES
-# A list of application processes to target for quitting. Names should match what is displayed for the process in Activity Monitor (e.g. "Chess", not "Chess.app"). If no processes need to be quit, comment these array values out.
-processNames=(
-  "Adobe AIR Application Installer"
-  "Adobe AIR Installer"
-)
-
-
-# FILE PATHS
-# A list of full file paths to target for launchd unload and removal. Leave off trailing slashes from directory paths. If no files need to be manually deleted, comment these array values out.
-resourceFiles=(
-  "/Applications/Adobe/Flash Player/AddIns/airappinstaller"
-  "/Applications/Utilities/Adobe AIR Application Installer.app"
-  "/Applications/Utilities/Adobe AIR Uninstaller.app"
-  "/Library/Frameworks/Adobe AIR.framework"
-)
 
 
 
@@ -73,57 +45,58 @@ resourceFiles=(
 
 
 
-# Runs vendor uninstallers.
-run_vendor_uninstallers () {
-  for uninstaller in "${vendorUninstallers[@]}"; do
-    if [[ -e "$uninstaller" ]]; then
-      ./"${uninstaller}" -uninstall
-    else
-      echo "Vendor uninstaller not found at ${uninstaller}."
-    fi
-  done
+# Runs specified vendor uninstaller.
+run_vendor_uninstaller () {
+
+  if [ -e "${1}" ]; then
+    echo "Running vendor uninstaller: ${1}"
+    ./"${1}"
+  else
+    echo "Vendor uninstaller not found at ${1}."
+  fi
+
 }
 
 
-# Quits target processes.
-quit_processes () {
+# Quits specified process.
+quit_process () {
+
   currentProcesses=$(/bin/ps aux)
-  for process in "${processNames[@]}"; do
-    if echo "$currentProcesses" | /usr/bin/grep -q "$process"; then
-      /bin/launchctl asuser "$loggedInUserUID" /usr/bin/osascript -e "tell application \"${process}\" to quit"
-      echo "Quit ${process}."
-    fi
-  done
+  if echo "$currentProcesses" | /usr/bin/grep -q "${1}"; then
+    /bin/launchctl asuser "$loggedInUserUID" /usr/bin/osascript -e "tell application \"${1}\" to quit"
+    echo "Quit ${1}."
+  fi
+
 }
 
 
-# Removes all remaining resource files.
-delete_files () {
-  for targetFile in "${resourceFiles[@]}"; do
+# Removes specified file.
+delete_file () {
+
     # Check if file exists.
-    if [ -e "$targetFile" ]; then
+    if [ -e "${1}" ]; then
       # Check if file is a plist.
-      if echo "$targetFile" | /usr/bin/grep -q ".plist"; then
+      if echo "${1}" | /usr/bin/grep -q ".plist"; then
         # If plist is loaded as LaunchAgent or LaunchDaemon, unload it.
-        justThePlist=$(/usr/bin/basename "$targetFile" | /usr/bin/awk -F.plist '{print $1}')
-        if echo "$launchAgentCheck" | /usr/bin/grep -q "$justThePlist"; then
-          /bin/launchctl asuser "$loggedInUserUID" /bin/launchctl unload "$targetFile"
-          echo "Unloaded LaunchAgent at ${targetFile}."
-        elif echo "$launchDaemonCheck" | /usr/bin/grep -q "$justThePlist"; then
-          /bin/launchctl unload "$targetFile"
-          echo "Unloaded LaunchDaemon at ${targetFile}."
+        justThePlist=$(/usr/bin/basename "${1}" | /usr/bin/awk -F.plist '{print $1}')
+        if /bin/launchctl asuser "$loggedInUserUID" /bin/launchctl list | /usr/bin/grep -q "$justThePlist"; then
+          /bin/launchctl asuser "$loggedInUserUID" /bin/launchctl unload "${1}"
+          echo "Unloaded LaunchAgent at ${1}."
+        elif /bin/launchctl list | /usr/bin/grep -q "$justThePlist"; then
+          /bin/launchctl unload "${1}"
+          echo "Unloaded LaunchDaemon at ${1}."
         fi
       fi
       # Remove system immutable flag if present.
-      if /bin/ls -ldO "$targetFile" | /usr/bin/awk '{print $5}' | /usr/bin/grep -q "schg"; then
-        /usr/bin/chflags -R noschg "$targetFile"
-        echo "Removed system immutable flag for ${targetFile}."
+      if /bin/ls -ldO "${1}" | /usr/bin/awk '{print $5}' | /usr/bin/grep -q "schg"; then
+        /usr/bin/chflags -R noschg "${1}"
+        echo "Removed system immutable flag for ${1}."
       fi
       # Remove file.
-      /bin/rm -rf "$targetFile"
-      echo "Removed ${targetFile}."
+      /bin/rm -rf "${1}"
+      echo "Removed ${1}."
     fi
-  done
+
 }
 
 
@@ -132,23 +105,23 @@ delete_files () {
 
 
 
-# Each function will only execute if the respective source array is not empty or undefined.
-if [[ -n "${vendorUninstallers[*]}" ]]; then
-  echo "Running vendor uninstallers..."
-  run_vendor_uninstallers
-fi
+# VENDOR UNINSTALLERS
+# For each vendor-provided uninstallation tool file path that exists on the system, run the run_vendor_uninstaller function calling that path to run it. Note that vendor uninstaller workflows may differ greatly from app to app. Some vendors may use their own command-line tools with custom flags or other workflows to accomplish this task (that's why this script exists!), so make any necessary changes to the below commands if the uninstallation workflow isn't simply calling executable files. Call the function again for each additional uninstaller. If the vendor did not provide an uninstaller workflow, comment out or remove this line.
+run_vendor_uninstaller "/Applications/Utilities/Adobe AIR Uninstaller.app/Contents/MacOS/Adobe AIR Installer"
 
 
-if [[ -n "${processNames[*]}" ]]; then
-  echo "Quitting processes (if running)..."
-  quit_processes
-fi
+# PROCESSES
+# For each process related to the target product, run the quit_process function calling that process name to quit it. Names should match what is displayed for the process in Activity Monitor (e.g. "Chess", not "Chess.app"). Call the function again for each additional process. If no processes need to be quit, comment out or remove this line.
+quit_process "Adobe AIR Application Installer"
+quit_process "Adobe AIR Installer"
 
 
-if [[ -n "${resourceFiles[*]}" ]]; then
-  echo "Removing files (if present)..."
-  delete_files
-fi
+# FILE PATHS
+# For each file and/or folder related to the target product, run the delete_file function calling that file name. Leave off trailing slashes from directory paths. Call the function again for each additional file. If no files need to be deleted, comment out or remove this line.
+delete_file "/Applications/Adobe/Flash Player/AddIns/airappinstaller"
+delete_file "/Applications/Utilities/Adobe AIR Application Installer.app"
+delete_file "/Applications/Utilities/Adobe AIR Uninstaller.app"
+delete_file "/Library/Frameworks/Adobe AIR.framework"
 
 
 

--- a/scripts/script-templates/uninstaller-template/Uninstall Adobe AIR.sh
+++ b/scripts/script-templates/uninstaller-template/Uninstall Adobe AIR.sh
@@ -6,7 +6,7 @@
 #     Description:  A template script to assist with the uninstallation of macOS products where the vendor has missing or incomplete removal solutions. Attempts vendor uninstall by running all provided uninstallation executables, quits all running target processes, then removes all associated target files.
 #                   https://github.com/palantir/jamf-pro-scripts/tree/main/scripts/script-templates/uninstaller-template
 #         Created:  2017-10-23
-#   Last Modified:  2023-07-17
+#   Last Modified:  2023-07-18
 #         Version:  2.0pal1
 #
 #
@@ -73,29 +73,29 @@ quit_process () {
 # Removes specified file.
 delete_file () {
 
-    # Check if file exists.
-    if [ -e "${1}" ]; then
-      # Check if file is a plist.
-      if echo "${1}" | /usr/bin/grep -q ".plist"; then
-        # If plist is loaded as LaunchAgent or LaunchDaemon, unload it.
-        justThePlist=$(/usr/bin/basename "${1}" | /usr/bin/awk -F.plist '{print $1}')
-        if /bin/launchctl asuser "$loggedInUserUID" /bin/launchctl list | /usr/bin/grep -q "$justThePlist"; then
-          /bin/launchctl asuser "$loggedInUserUID" /bin/launchctl unload "${1}"
-          echo "Unloaded LaunchAgent at ${1}."
-        elif /bin/launchctl list | /usr/bin/grep -q "$justThePlist"; then
-          /bin/launchctl unload "${1}"
-          echo "Unloaded LaunchDaemon at ${1}."
-        fi
+  # Check if file exists.
+  if [ -e "${1}" ]; then
+    # Check if file is a plist.
+    if echo "${1}" | /usr/bin/grep -q ".plist"; then
+      # If plist is loaded as LaunchAgent or LaunchDaemon, unload it.
+      justThePlist=$(/usr/bin/basename "${1}" | /usr/bin/awk -F.plist '{print $1}')
+      if /bin/launchctl asuser "$loggedInUserUID" /bin/launchctl list | /usr/bin/grep -q "$justThePlist"; then
+        /bin/launchctl asuser "$loggedInUserUID" /bin/launchctl unload "${1}"
+        echo "Unloaded LaunchAgent at ${1}."
+      elif /bin/launchctl list | /usr/bin/grep -q "$justThePlist"; then
+        /bin/launchctl unload "${1}"
+        echo "Unloaded LaunchDaemon at ${1}."
       fi
-      # Remove system immutable flag if present.
-      if /bin/ls -ldO "${1}" | /usr/bin/awk '{print $5}' | /usr/bin/grep -q "schg"; then
-        /usr/bin/chflags -R noschg "${1}"
-        echo "Removed system immutable flag for ${1}."
-      fi
-      # Remove file.
-      /bin/rm -rf "${1}"
-      echo "Removed ${1}."
     fi
+    # Remove system immutable flag if present.
+    if /bin/ls -ldO "${1}" | /usr/bin/awk '{print $5}' | /usr/bin/grep -q "schg"; then
+      /usr/bin/chflags -R noschg "${1}"
+      echo "Removed system immutable flag for ${1}."
+    fi
+    # Remove file.
+    /bin/rm -rf "${1}"
+    echo "Removed ${1}."
+  fi
 
 }
 

--- a/scripts/script-templates/uninstaller-template/Uninstall Adobe Acrobat Reader.sh
+++ b/scripts/script-templates/uninstaller-template/Uninstall Adobe Acrobat Reader.sh
@@ -6,7 +6,7 @@
 #     Description:  A template script to assist with the uninstallation of macOS products where the vendor has missing or incomplete removal solutions. Attempts vendor uninstall by running all provided uninstallation executables, quits all running target processes, then removes all associated target files.
 #                   https://github.com/palantir/jamf-pro-scripts/tree/main/scripts/script-templates/uninstaller-template
 #         Created:  2017-10-23
-#   Last Modified:  2023-07-17
+#   Last Modified:  2023-07-18
 #         Version:  2.0pal1
 #
 #
@@ -48,29 +48,29 @@ loggedInUserHome=$(/usr/bin/dscl . -read "/Users/${loggedInUser}" NFSHomeDirecto
 # Removes specified file.
 delete_file () {
 
-    # Check if file exists.
-    if [ -e "${1}" ]; then
-      # Check if file is a plist.
-      if echo "${1}" | /usr/bin/grep -q ".plist"; then
-        # If plist is loaded as LaunchAgent or LaunchDaemon, unload it.
-        justThePlist=$(/usr/bin/basename "${1}" | /usr/bin/awk -F.plist '{print $1}')
-        if /bin/launchctl asuser "$loggedInUserUID" /bin/launchctl list | /usr/bin/grep -q "$justThePlist"; then
-          /bin/launchctl asuser "$loggedInUserUID" /bin/launchctl unload "${1}"
-          echo "Unloaded LaunchAgent at ${1}."
-        elif /bin/launchctl list | /usr/bin/grep -q "$justThePlist"; then
-          /bin/launchctl unload "${1}"
-          echo "Unloaded LaunchDaemon at ${1}."
-        fi
+  # Check if file exists.
+  if [ -e "${1}" ]; then
+    # Check if file is a plist.
+    if echo "${1}" | /usr/bin/grep -q ".plist"; then
+      # If plist is loaded as LaunchAgent or LaunchDaemon, unload it.
+      justThePlist=$(/usr/bin/basename "${1}" | /usr/bin/awk -F.plist '{print $1}')
+      if /bin/launchctl asuser "$loggedInUserUID" /bin/launchctl list | /usr/bin/grep -q "$justThePlist"; then
+        /bin/launchctl asuser "$loggedInUserUID" /bin/launchctl unload "${1}"
+        echo "Unloaded LaunchAgent at ${1}."
+      elif /bin/launchctl list | /usr/bin/grep -q "$justThePlist"; then
+        /bin/launchctl unload "${1}"
+        echo "Unloaded LaunchDaemon at ${1}."
       fi
-      # Remove system immutable flag if present.
-      if /bin/ls -ldO "${1}" | /usr/bin/awk '{print $5}' | /usr/bin/grep -q "schg"; then
-        /usr/bin/chflags -R noschg "${1}"
-        echo "Removed system immutable flag for ${1}."
-      fi
-      # Remove file.
-      /bin/rm -rf "${1}"
-      echo "Removed ${1}."
     fi
+    # Remove system immutable flag if present.
+    if /bin/ls -ldO "${1}" | /usr/bin/awk '{print $5}' | /usr/bin/grep -q "schg"; then
+      /usr/bin/chflags -R noschg "${1}"
+      echo "Removed system immutable flag for ${1}."
+    fi
+    # Remove file.
+    /bin/rm -rf "${1}"
+    echo "Removed ${1}."
+  fi
 
 }
 

--- a/scripts/script-templates/uninstaller-template/Uninstall Adobe Acrobat Reader.sh
+++ b/scripts/script-templates/uninstaller-template/Uninstall Adobe Acrobat Reader.sh
@@ -1,13 +1,13 @@
-#!/bin/bash
+#!/bin/sh
 
 ###
 #
 #            Name:  Uninstall Adobe Acrobat Reader.sh
-#     Description:  A template script to assist with the uninstallation of macOS products where the vendor has missing or incomplete removal solutions. Attempts vendor uninstall by running all provided uninstallation executables, quits all running target processes, unloads all associated launchd tasks, then removes all associated files.
+#     Description:  A template script to assist with the uninstallation of macOS products where the vendor has missing or incomplete removal solutions. Attempts vendor uninstall by running all provided uninstallation executables, quits all running target processes, then removes all associated target files.
 #                   https://github.com/palantir/jamf-pro-scripts/tree/main/scripts/script-templates/uninstaller-template
 #         Created:  2017-10-23
-#   Last Modified:  2023-05-02
-#         Version:  1.3.10pal1
+#   Last Modified:  2023-07-17
+#         Version:  2.0pal1
 #
 #
 # Copyright 2017 Palantir Technologies, Inc.
@@ -33,22 +33,11 @@
 
 
 
-# ENVIRONMENT VARIABLES (leave as-is)
 loggedInUser=$(/usr/bin/stat -f%Su "/dev/console")
+loggedInUserUID=$(/usr/bin/id -u "$loggedInUser")
 # For any file paths used later in this script, use "$loggedInUserHome" for the current user's home folder path. Don't just assume the home folder is at /Users/${loggedInUser}.
 # shellcheck disable=SC2034
 loggedInUserHome=$(/usr/bin/dscl . -read "/Users/${loggedInUser}" NFSHomeDirectory | /usr/bin/awk '{print $NF}')
-loggedInUserUID=$(/usr/bin/id -u "$loggedInUser")
-launchAgentCheck=$(/bin/launchctl asuser "$loggedInUserUID" /bin/launchctl list)
-launchDaemonCheck=$(/bin/launchctl list)
-
-
-# FILE PATHS
-# A list of full file paths to target for launchd unload and removal. Leave off trailing slashes from directory paths. If no files need to be manually deleted, comment these array values out.
-resourceFiles=(
-  "/Applications/Adobe Acrobat Reader DC.app"
-  "/Applications/Adobe Reader.app"
-)
 
 
 
@@ -56,33 +45,33 @@ resourceFiles=(
 
 
 
-# Removes all remaining resource files.
-delete_files () {
-  for targetFile in "${resourceFiles[@]}"; do
+# Removes specified file.
+delete_file () {
+
     # Check if file exists.
-    if [ -e "$targetFile" ]; then
+    if [ -e "${1}" ]; then
       # Check if file is a plist.
-      if echo "$targetFile" | /usr/bin/grep -q ".plist"; then
+      if echo "${1}" | /usr/bin/grep -q ".plist"; then
         # If plist is loaded as LaunchAgent or LaunchDaemon, unload it.
-        justThePlist=$(/usr/bin/basename "$targetFile" | /usr/bin/awk -F.plist '{print $1}')
-        if echo "$launchAgentCheck" | /usr/bin/grep -q "$justThePlist"; then
-          /bin/launchctl asuser "$loggedInUserUID" /bin/launchctl unload "$targetFile"
-          echo "Unloaded LaunchAgent at ${targetFile}."
-        elif echo "$launchDaemonCheck" | /usr/bin/grep -q "$justThePlist"; then
-          /bin/launchctl unload "$targetFile"
-          echo "Unloaded LaunchDaemon at ${targetFile}."
+        justThePlist=$(/usr/bin/basename "${1}" | /usr/bin/awk -F.plist '{print $1}')
+        if /bin/launchctl asuser "$loggedInUserUID" /bin/launchctl list | /usr/bin/grep -q "$justThePlist"; then
+          /bin/launchctl asuser "$loggedInUserUID" /bin/launchctl unload "${1}"
+          echo "Unloaded LaunchAgent at ${1}."
+        elif /bin/launchctl list | /usr/bin/grep -q "$justThePlist"; then
+          /bin/launchctl unload "${1}"
+          echo "Unloaded LaunchDaemon at ${1}."
         fi
       fi
       # Remove system immutable flag if present.
-      if /bin/ls -ldO "$targetFile" | /usr/bin/awk '{print $5}' | /usr/bin/grep -q "schg"; then
-        /usr/bin/chflags -R noschg "$targetFile"
-        echo "Removed system immutable flag for ${targetFile}."
+      if /bin/ls -ldO "${1}" | /usr/bin/awk '{print $5}' | /usr/bin/grep -q "schg"; then
+        /usr/bin/chflags -R noschg "${1}"
+        echo "Removed system immutable flag for ${1}."
       fi
       # Remove file.
-      /bin/rm -rf "$targetFile"
-      echo "Removed ${targetFile}."
+      /bin/rm -rf "${1}"
+      echo "Removed ${1}."
     fi
-  done
+
 }
 
 
@@ -91,11 +80,10 @@ delete_files () {
 
 
 
-# Each function will only execute if the respective source array is not empty or undefined.
-if [[ -n "${resourceFiles[*]}" ]]; then
-  echo "Removing files (if present)..."
-  delete_files
-fi
+# FILE PATHS
+# For each file and/or folder related to the target product, run the delete_file function calling that file name. Leave off trailing slashes from directory paths. Call the function again for each additional file. If no files need to be deleted, comment out or remove this line.
+delete_file "/Applications/Adobe Acrobat Reader DC.app"
+delete_file "/Applications/Adobe Reader.app"
 
 
 

--- a/scripts/script-templates/uninstaller-template/Uninstall Adobe Acrobat.sh
+++ b/scripts/script-templates/uninstaller-template/Uninstall Adobe Acrobat.sh
@@ -1,13 +1,13 @@
-#!/bin/bash
+#!/bin/sh
 
 ###
 #
 #            Name:  Uninstall Adobe Acrobat.sh
-#     Description:  A template script to assist with the uninstallation of macOS products where the vendor has missing or incomplete removal solutions. Attempts vendor uninstall by running all provided uninstallation executables, quits all running target processes, unloads all associated launchd tasks, then removes all associated files.
+#     Description:  A template script to assist with the uninstallation of macOS products where the vendor has missing or incomplete removal solutions. Attempts vendor uninstall by running all provided uninstallation executables, quits all running target processes, then removes all associated target files.
 #                   https://github.com/palantir/jamf-pro-scripts/tree/main/scripts/script-templates/uninstaller-template
 #         Created:  2017-10-23
-#   Last Modified:  2023-05-02
-#         Version:  1.3.10pal1
+#   Last Modified:  2023-07-17
+#         Version:  2.0pal1
 #
 #
 # Copyright 2017 Palantir Technologies, Inc.
@@ -33,22 +33,11 @@
 
 
 
-# ENVIRONMENT VARIABLES (leave as-is)
 loggedInUser=$(/usr/bin/stat -f%Su "/dev/console")
+loggedInUserUID=$(/usr/bin/id -u "$loggedInUser")
 # For any file paths used later in this script, use "$loggedInUserHome" for the current user's home folder path. Don't just assume the home folder is at /Users/${loggedInUser}.
 # shellcheck disable=SC2034
 loggedInUserHome=$(/usr/bin/dscl . -read "/Users/${loggedInUser}" NFSHomeDirectory | /usr/bin/awk '{print $NF}')
-loggedInUserUID=$(/usr/bin/id -u "$loggedInUser")
-launchAgentCheck=$(/bin/launchctl asuser "$loggedInUserUID" /bin/launchctl list)
-launchDaemonCheck=$(/bin/launchctl list)
-
-
-# FILE PATHS
-# A list of full file paths to target for launchd unload and removal. Leave off trailing slashes from directory paths. If no files need to be manually deleted, comment these array values out.
-resourceFiles=(
-  "/Applications/Adobe Acrobat DC/Adobe Acrobat.app"
-  "/Applications/Adobe Acrobat DC"
-)
 
 
 
@@ -56,33 +45,33 @@ resourceFiles=(
 
 
 
-# Removes all remaining resource files.
-delete_files () {
-  for targetFile in "${resourceFiles[@]}"; do
+# Removes specified file.
+delete_file () {
+
     # Check if file exists.
-    if [ -e "$targetFile" ]; then
+    if [ -e "${1}" ]; then
       # Check if file is a plist.
-      if echo "$targetFile" | /usr/bin/grep -q ".plist"; then
+      if echo "${1}" | /usr/bin/grep -q ".plist"; then
         # If plist is loaded as LaunchAgent or LaunchDaemon, unload it.
-        justThePlist=$(/usr/bin/basename "$targetFile" | /usr/bin/awk -F.plist '{print $1}')
-        if echo "$launchAgentCheck" | /usr/bin/grep -q "$justThePlist"; then
-          /bin/launchctl asuser "$loggedInUserUID" /bin/launchctl unload "$targetFile"
-          echo "Unloaded LaunchAgent at ${targetFile}."
-        elif echo "$launchDaemonCheck" | /usr/bin/grep -q "$justThePlist"; then
-          /bin/launchctl unload "$targetFile"
-          echo "Unloaded LaunchDaemon at ${targetFile}."
+        justThePlist=$(/usr/bin/basename "${1}" | /usr/bin/awk -F.plist '{print $1}')
+        if /bin/launchctl asuser "$loggedInUserUID" /bin/launchctl list | /usr/bin/grep -q "$justThePlist"; then
+          /bin/launchctl asuser "$loggedInUserUID" /bin/launchctl unload "${1}"
+          echo "Unloaded LaunchAgent at ${1}."
+        elif /bin/launchctl list | /usr/bin/grep -q "$justThePlist"; then
+          /bin/launchctl unload "${1}"
+          echo "Unloaded LaunchDaemon at ${1}."
         fi
       fi
       # Remove system immutable flag if present.
-      if /bin/ls -ldO "$targetFile" | /usr/bin/awk '{print $5}' | /usr/bin/grep -q "schg"; then
-        /usr/bin/chflags -R noschg "$targetFile"
-        echo "Removed system immutable flag for ${targetFile}."
+      if /bin/ls -ldO "${1}" | /usr/bin/awk '{print $5}' | /usr/bin/grep -q "schg"; then
+        /usr/bin/chflags -R noschg "${1}"
+        echo "Removed system immutable flag for ${1}."
       fi
       # Remove file.
-      /bin/rm -rf "$targetFile"
-      echo "Removed ${targetFile}."
+      /bin/rm -rf "${1}"
+      echo "Removed ${1}."
     fi
-  done
+
 }
 
 
@@ -91,11 +80,10 @@ delete_files () {
 
 
 
-# Each function will only execute if the respective source array is not empty or undefined.
-if [[ -n "${resourceFiles[*]}" ]]; then
-  echo "Removing files (if present)..."
-  delete_files
-fi
+# FILE PATHS
+# For each file and/or folder related to the target product, run the delete_file function calling that file name. Leave off trailing slashes from directory paths. Call the function again for each additional file. If no files need to be deleted, comment out or remove this line.
+delete_file "/Applications/Adobe Acrobat DC/Adobe Acrobat.app"
+delete_file "/Applications/Adobe Acrobat DC"
 
 
 

--- a/scripts/script-templates/uninstaller-template/Uninstall Adobe Acrobat.sh
+++ b/scripts/script-templates/uninstaller-template/Uninstall Adobe Acrobat.sh
@@ -6,7 +6,7 @@
 #     Description:  A template script to assist with the uninstallation of macOS products where the vendor has missing or incomplete removal solutions. Attempts vendor uninstall by running all provided uninstallation executables, quits all running target processes, then removes all associated target files.
 #                   https://github.com/palantir/jamf-pro-scripts/tree/main/scripts/script-templates/uninstaller-template
 #         Created:  2017-10-23
-#   Last Modified:  2023-07-17
+#   Last Modified:  2023-07-18
 #         Version:  2.0pal1
 #
 #
@@ -48,29 +48,29 @@ loggedInUserHome=$(/usr/bin/dscl . -read "/Users/${loggedInUser}" NFSHomeDirecto
 # Removes specified file.
 delete_file () {
 
-    # Check if file exists.
-    if [ -e "${1}" ]; then
-      # Check if file is a plist.
-      if echo "${1}" | /usr/bin/grep -q ".plist"; then
-        # If plist is loaded as LaunchAgent or LaunchDaemon, unload it.
-        justThePlist=$(/usr/bin/basename "${1}" | /usr/bin/awk -F.plist '{print $1}')
-        if /bin/launchctl asuser "$loggedInUserUID" /bin/launchctl list | /usr/bin/grep -q "$justThePlist"; then
-          /bin/launchctl asuser "$loggedInUserUID" /bin/launchctl unload "${1}"
-          echo "Unloaded LaunchAgent at ${1}."
-        elif /bin/launchctl list | /usr/bin/grep -q "$justThePlist"; then
-          /bin/launchctl unload "${1}"
-          echo "Unloaded LaunchDaemon at ${1}."
-        fi
+  # Check if file exists.
+  if [ -e "${1}" ]; then
+    # Check if file is a plist.
+    if echo "${1}" | /usr/bin/grep -q ".plist"; then
+      # If plist is loaded as LaunchAgent or LaunchDaemon, unload it.
+      justThePlist=$(/usr/bin/basename "${1}" | /usr/bin/awk -F.plist '{print $1}')
+      if /bin/launchctl asuser "$loggedInUserUID" /bin/launchctl list | /usr/bin/grep -q "$justThePlist"; then
+        /bin/launchctl asuser "$loggedInUserUID" /bin/launchctl unload "${1}"
+        echo "Unloaded LaunchAgent at ${1}."
+      elif /bin/launchctl list | /usr/bin/grep -q "$justThePlist"; then
+        /bin/launchctl unload "${1}"
+        echo "Unloaded LaunchDaemon at ${1}."
       fi
-      # Remove system immutable flag if present.
-      if /bin/ls -ldO "${1}" | /usr/bin/awk '{print $5}' | /usr/bin/grep -q "schg"; then
-        /usr/bin/chflags -R noschg "${1}"
-        echo "Removed system immutable flag for ${1}."
-      fi
-      # Remove file.
-      /bin/rm -rf "${1}"
-      echo "Removed ${1}."
     fi
+    # Remove system immutable flag if present.
+    if /bin/ls -ldO "${1}" | /usr/bin/awk '{print $5}' | /usr/bin/grep -q "schg"; then
+      /usr/bin/chflags -R noschg "${1}"
+      echo "Removed system immutable flag for ${1}."
+    fi
+    # Remove file.
+    /bin/rm -rf "${1}"
+    echo "Removed ${1}."
+  fi
 
 }
 

--- a/scripts/script-templates/uninstaller-template/Uninstall Adobe Application.sh
+++ b/scripts/script-templates/uninstaller-template/Uninstall Adobe Application.sh
@@ -6,7 +6,7 @@
 #     Description:  A template script to assist with the uninstallation of macOS products where the vendor has missing or incomplete removal solutions. Attempts vendor uninstall by running all provided uninstallation executables, quits all running target processes, then removes all associated target files.
 #                   https://github.com/palantir/jamf-pro-scripts/tree/main/scripts/script-templates/uninstaller-template
 #         Created:  2017-10-23
-#   Last Modified:  2023-07-17
+#   Last Modified:  2023-07-18
 #         Version:  2.0pal1
 #
 #
@@ -65,29 +65,29 @@ check_jamf_pro_arguments () {
 # Removes specified file.
 delete_file () {
 
-    # Check if file exists.
-    if [ -e "${1}" ]; then
-      # Check if file is a plist.
-      if echo "${1}" | /usr/bin/grep -q ".plist"; then
-        # If plist is loaded as LaunchAgent or LaunchDaemon, unload it.
-        justThePlist=$(/usr/bin/basename "${1}" | /usr/bin/awk -F.plist '{print $1}')
-        if /bin/launchctl asuser "$loggedInUserUID" /bin/launchctl list | /usr/bin/grep -q "$justThePlist"; then
-          /bin/launchctl asuser "$loggedInUserUID" /bin/launchctl unload "${1}"
-          echo "Unloaded LaunchAgent at ${1}."
-        elif /bin/launchctl list | /usr/bin/grep -q "$justThePlist"; then
-          /bin/launchctl unload "${1}"
-          echo "Unloaded LaunchDaemon at ${1}."
-        fi
+  # Check if file exists.
+  if [ -e "${1}" ]; then
+    # Check if file is a plist.
+    if echo "${1}" | /usr/bin/grep -q ".plist"; then
+      # If plist is loaded as LaunchAgent or LaunchDaemon, unload it.
+      justThePlist=$(/usr/bin/basename "${1}" | /usr/bin/awk -F.plist '{print $1}')
+      if /bin/launchctl asuser "$loggedInUserUID" /bin/launchctl list | /usr/bin/grep -q "$justThePlist"; then
+        /bin/launchctl asuser "$loggedInUserUID" /bin/launchctl unload "${1}"
+        echo "Unloaded LaunchAgent at ${1}."
+      elif /bin/launchctl list | /usr/bin/grep -q "$justThePlist"; then
+        /bin/launchctl unload "${1}"
+        echo "Unloaded LaunchDaemon at ${1}."
       fi
-      # Remove system immutable flag if present.
-      if /bin/ls -ldO "${1}" | /usr/bin/awk '{print $5}' | /usr/bin/grep -q "schg"; then
-        /usr/bin/chflags -R noschg "${1}"
-        echo "Removed system immutable flag for ${1}."
-      fi
-      # Remove file.
-      /bin/rm -rf "${1}"
-      echo "Removed ${1}."
     fi
+    # Remove system immutable flag if present.
+    if /bin/ls -ldO "${1}" | /usr/bin/awk '{print $5}' | /usr/bin/grep -q "schg"; then
+      /usr/bin/chflags -R noschg "${1}"
+      echo "Removed system immutable flag for ${1}."
+    fi
+    # Remove file.
+    /bin/rm -rf "${1}"
+    echo "Removed ${1}."
+  fi
 
 }
 

--- a/scripts/script-templates/uninstaller-template/Uninstall Adobe Creative Cloud Desktop.sh
+++ b/scripts/script-templates/uninstaller-template/Uninstall Adobe Creative Cloud Desktop.sh
@@ -6,7 +6,7 @@
 #     Description:  A template script to assist with the uninstallation of macOS products where the vendor has missing or incomplete removal solutions. Attempts vendor uninstall by running all provided uninstallation executables, quits all running target processes, then removes all associated target files.
 #                   https://github.com/palantir/jamf-pro-scripts/tree/main/scripts/script-templates/uninstaller-template
 #         Created:  2017-10-23
-#   Last Modified:  2023-07-17
+#   Last Modified:  2023-07-18
 #         Version:  2.0pal1
 #
 #
@@ -48,29 +48,29 @@ loggedInUserHome=$(/usr/bin/dscl . -read "/Users/${loggedInUser}" NFSHomeDirecto
 # Removes specified file.
 delete_file () {
 
-    # Check if file exists.
-    if [ -e "${1}" ]; then
-      # Check if file is a plist.
-      if echo "${1}" | /usr/bin/grep -q ".plist"; then
-        # If plist is loaded as LaunchAgent or LaunchDaemon, unload it.
-        justThePlist=$(/usr/bin/basename "${1}" | /usr/bin/awk -F.plist '{print $1}')
-        if /bin/launchctl asuser "$loggedInUserUID" /bin/launchctl list | /usr/bin/grep -q "$justThePlist"; then
-          /bin/launchctl asuser "$loggedInUserUID" /bin/launchctl unload "${1}"
-          echo "Unloaded LaunchAgent at ${1}."
-        elif /bin/launchctl list | /usr/bin/grep -q "$justThePlist"; then
-          /bin/launchctl unload "${1}"
-          echo "Unloaded LaunchDaemon at ${1}."
-        fi
+  # Check if file exists.
+  if [ -e "${1}" ]; then
+    # Check if file is a plist.
+    if echo "${1}" | /usr/bin/grep -q ".plist"; then
+      # If plist is loaded as LaunchAgent or LaunchDaemon, unload it.
+      justThePlist=$(/usr/bin/basename "${1}" | /usr/bin/awk -F.plist '{print $1}')
+      if /bin/launchctl asuser "$loggedInUserUID" /bin/launchctl list | /usr/bin/grep -q "$justThePlist"; then
+        /bin/launchctl asuser "$loggedInUserUID" /bin/launchctl unload "${1}"
+        echo "Unloaded LaunchAgent at ${1}."
+      elif /bin/launchctl list | /usr/bin/grep -q "$justThePlist"; then
+        /bin/launchctl unload "${1}"
+        echo "Unloaded LaunchDaemon at ${1}."
       fi
-      # Remove system immutable flag if present.
-      if /bin/ls -ldO "${1}" | /usr/bin/awk '{print $5}' | /usr/bin/grep -q "schg"; then
-        /usr/bin/chflags -R noschg "${1}"
-        echo "Removed system immutable flag for ${1}."
-      fi
-      # Remove file.
-      /bin/rm -rf "${1}"
-      echo "Removed ${1}."
     fi
+    # Remove system immutable flag if present.
+    if /bin/ls -ldO "${1}" | /usr/bin/awk '{print $5}' | /usr/bin/grep -q "schg"; then
+      /usr/bin/chflags -R noschg "${1}"
+      echo "Removed system immutable flag for ${1}."
+    fi
+    # Remove file.
+    /bin/rm -rf "${1}"
+    echo "Removed ${1}."
+  fi
 
 }
 

--- a/scripts/script-templates/uninstaller-template/Uninstall Adobe Creative Cloud Desktop.sh
+++ b/scripts/script-templates/uninstaller-template/Uninstall Adobe Creative Cloud Desktop.sh
@@ -1,13 +1,13 @@
-#!/bin/bash
+#!/bin/sh
 
 ###
 #
 #            Name:  Uninstall Adobe Creative Cloud Desktop.sh
-#     Description:  A template script to assist with the uninstallation of macOS products where the vendor has missing or incomplete removal solutions. Attempts vendor uninstall by running all provided uninstallation executables, quits all running target processes, unloads all associated launchd tasks, then removes all associated files.
+#     Description:  A template script to assist with the uninstallation of macOS products where the vendor has missing or incomplete removal solutions. Attempts vendor uninstall by running all provided uninstallation executables, quits all running target processes, then removes all associated target files.
 #                   https://github.com/palantir/jamf-pro-scripts/tree/main/scripts/script-templates/uninstaller-template
 #         Created:  2017-10-23
-#   Last Modified:  2023-05-02
-#         Version:  1.3.10pal1
+#   Last Modified:  2023-07-17
+#         Version:  2.0pal1
 #
 #
 # Copyright 2017 Palantir Technologies, Inc.
@@ -33,31 +33,11 @@
 
 
 
-# ENVIRONMENT VARIABLES (leave as-is)
 loggedInUser=$(/usr/bin/stat -f%Su "/dev/console")
+loggedInUserUID=$(/usr/bin/id -u "$loggedInUser")
 # For any file paths used later in this script, use "$loggedInUserHome" for the current user's home folder path. Don't just assume the home folder is at /Users/${loggedInUser}.
 # shellcheck disable=SC2034
 loggedInUserHome=$(/usr/bin/dscl . -read "/Users/${loggedInUser}" NFSHomeDirectory | /usr/bin/awk '{print $NF}')
-loggedInUserUID=$(/usr/bin/id -u "$loggedInUser")
-launchAgentCheck=$(/bin/launchctl asuser "$loggedInUserUID" /bin/launchctl list)
-launchDaemonCheck=$(/bin/launchctl list)
-
-
-# FILE PATHS
-# A list of full file paths to target for launchd unload and removal. Leave off trailing slashes from directory paths. If no files need to be manually deleted, comment these array values out.
-resourceFiles=(
-  "/Applications/Utilities/Adobe Creative Cloud/ACC/Creative Cloud.app"
-  "/Applications/Utilities/Adobe Creative Cloud/AppsPanel/Updater/Adobe Application Updater.app"
-  "/Applications/Utilities/Adobe Creative Cloud/CCXProcess/CCXProcess.app"
-  "/Applications/Utilities/Adobe Creative Cloud/HDCore/Install.app"
-  "/Applications/Utilities/Adobe Creative Cloud/HDCore/Uninstaller.app"
-  "/Applications/Utilities/Adobe Creative Cloud/Utils/Creative Cloud Desktop App.app"
-  "/Applications/Utilities/Adobe Creative Cloud/Utils/Creative Cloud Installer.app"
-  "/Applications/Utilities/Adobe Creative Cloud/Utils/Creative Cloud Uninstaller.app"
-  "/Applications/Utilities/Adobe Creative Cloud/"
-  "/Applications/Utilities/Adobe Creative Cloud Experience/CCXProcess.app"
-  "/Applications/Utilities/Adobe Creative Cloud Experience"
-)
 
 
 
@@ -65,33 +45,33 @@ resourceFiles=(
 
 
 
-# Removes all remaining resource files.
-delete_files () {
-  for targetFile in "${resourceFiles[@]}"; do
+# Removes specified file.
+delete_file () {
+
     # Check if file exists.
-    if [ -e "$targetFile" ]; then
+    if [ -e "${1}" ]; then
       # Check if file is a plist.
-      if echo "$targetFile" | /usr/bin/grep -q ".plist"; then
+      if echo "${1}" | /usr/bin/grep -q ".plist"; then
         # If plist is loaded as LaunchAgent or LaunchDaemon, unload it.
-        justThePlist=$(/usr/bin/basename "$targetFile" | /usr/bin/awk -F.plist '{print $1}')
-        if echo "$launchAgentCheck" | /usr/bin/grep -q "$justThePlist"; then
-          /bin/launchctl asuser "$loggedInUserUID" /bin/launchctl unload "$targetFile"
-          echo "Unloaded LaunchAgent at ${targetFile}."
-        elif echo "$launchDaemonCheck" | /usr/bin/grep -q "$justThePlist"; then
-          /bin/launchctl unload "$targetFile"
-          echo "Unloaded LaunchDaemon at ${targetFile}."
+        justThePlist=$(/usr/bin/basename "${1}" | /usr/bin/awk -F.plist '{print $1}')
+        if /bin/launchctl asuser "$loggedInUserUID" /bin/launchctl list | /usr/bin/grep -q "$justThePlist"; then
+          /bin/launchctl asuser "$loggedInUserUID" /bin/launchctl unload "${1}"
+          echo "Unloaded LaunchAgent at ${1}."
+        elif /bin/launchctl list | /usr/bin/grep -q "$justThePlist"; then
+          /bin/launchctl unload "${1}"
+          echo "Unloaded LaunchDaemon at ${1}."
         fi
       fi
       # Remove system immutable flag if present.
-      if /bin/ls -ldO "$targetFile" | /usr/bin/awk '{print $5}' | /usr/bin/grep -q "schg"; then
-        /usr/bin/chflags -R noschg "$targetFile"
-        echo "Removed system immutable flag for ${targetFile}."
+      if /bin/ls -ldO "${1}" | /usr/bin/awk '{print $5}' | /usr/bin/grep -q "schg"; then
+        /usr/bin/chflags -R noschg "${1}"
+        echo "Removed system immutable flag for ${1}."
       fi
       # Remove file.
-      /bin/rm -rf "$targetFile"
-      echo "Removed ${targetFile}."
+      /bin/rm -rf "${1}"
+      echo "Removed ${1}."
     fi
-  done
+
 }
 
 
@@ -100,11 +80,19 @@ delete_files () {
 
 
 
-# Each function will only execute if the respective source array is not empty or undefined.
-if [[ -n "${resourceFiles[*]}" ]]; then
-  echo "Removing files (if present)..."
-  delete_files
-fi
+# FILE PATHS
+# For each file and/or folder related to the target product, run the delete_file function calling that file name. Leave off trailing slashes from directory paths. Call the function again for each additional file. If no files need to be deleted, comment out or remove this line.
+delete_file "/Applications/Utilities/Adobe Creative Cloud/ACC/Creative Cloud.app"
+delete_file "/Applications/Utilities/Adobe Creative Cloud/AppsPanel/Updater/Adobe Application Updater.app"
+delete_file "/Applications/Utilities/Adobe Creative Cloud/CCXProcess/CCXProcess.app"
+delete_file "/Applications/Utilities/Adobe Creative Cloud/HDCore/Install.app"
+delete_file "/Applications/Utilities/Adobe Creative Cloud/HDCore/Uninstaller.app"
+delete_file "/Applications/Utilities/Adobe Creative Cloud/Utils/Creative Cloud Desktop App.app"
+delete_file "/Applications/Utilities/Adobe Creative Cloud/Utils/Creative Cloud Installer.app"
+delete_file "/Applications/Utilities/Adobe Creative Cloud/Utils/Creative Cloud Uninstaller.app"
+delete_file "/Applications/Utilities/Adobe Creative Cloud/"
+delete_file "/Applications/Utilities/Adobe Creative Cloud Experience/CCXProcess.app"
+delete_file "/Applications/Utilities/Adobe Creative Cloud Experience"
 
 
 

--- a/scripts/script-templates/uninstaller-template/Uninstall Adobe Flash.sh
+++ b/scripts/script-templates/uninstaller-template/Uninstall Adobe Flash.sh
@@ -1,13 +1,13 @@
-#!/bin/bash
+#!/bin/sh
 
 ###
 #
 #            Name:  Uninstall Adobe Flash.sh
-#     Description:  A template script to assist with the uninstallation of macOS products where the vendor has missing or incomplete removal solutions. Attempts vendor uninstall by running all provided uninstallation executables, quits all running target processes, unloads all associated launchd tasks, then removes all associated files.
+#     Description:  A template script to assist with the uninstallation of macOS products where the vendor has missing or incomplete removal solutions. Attempts vendor uninstall by running all provided uninstallation executables, quits all running target processes, then removes all associated target files.
 #                   https://github.com/palantir/jamf-pro-scripts/tree/main/scripts/script-templates/uninstaller-template
 #         Created:  2017-10-23
-#   Last Modified:  2023-05-02
-#         Version:  1.3.10pal1
+#   Last Modified:  2023-07-17
+#         Version:  2.0pal1
 #
 #
 # Copyright 2017 Palantir Technologies, Inc.
@@ -33,33 +33,11 @@
 
 
 
-# ENVIRONMENT VARIABLES (leave as-is)
 loggedInUser=$(/usr/bin/stat -f%Su "/dev/console")
+loggedInUserUID=$(/usr/bin/id -u "$loggedInUser")
 # For any file paths used later in this script, use "$loggedInUserHome" for the current user's home folder path. Don't just assume the home folder is at /Users/${loggedInUser}.
 # shellcheck disable=SC2034
 loggedInUserHome=$(/usr/bin/dscl . -read "/Users/${loggedInUser}" NFSHomeDirectory | /usr/bin/awk '{print $NF}')
-loggedInUserUID=$(/usr/bin/id -u "$loggedInUser")
-launchAgentCheck=$(/bin/launchctl asuser "$loggedInUserUID" /bin/launchctl list)
-launchDaemonCheck=$(/bin/launchctl list)
-
-
-# PROCESSES
-# A list of application processes to target for quitting. Names should match what is displayed for the process in Activity Monitor (e.g. "Chess", not "Chess.app"). If no processes need to be quit, comment these array values out.
-processNames=(
-  "Adobe Flash Player Install Manager"
-)
-
-
-# FILE PATHS
-# A list of full file paths to target for launchd unload and removal. Leave off trailing slashes from directory paths. If no files need to be manually deleted, comment these array values out.
-resourceFiles=(
-  "/Applications/Utilities/Adobe Flash Player Install Manager.app"
-  "/Library/Internet Plug-Ins/Flash Player.plugin"
-  "/Library/Internet Plug-Ins/flashplayer.xpt"
-  "/Library/Internet Plug-Ins/PepperFlashPlayer"
-  "/Library/PreferencePanes/Flash Player.prefPane"
-  "/Library/Receipts/Adobe Flash Player.pkg"
-)
 
 
 
@@ -67,45 +45,45 @@ resourceFiles=(
 
 
 
-# Quits target processes.
-quit_processes () {
+# Quits specified process.
+quit_process () {
+
   currentProcesses=$(/bin/ps aux)
-  for process in "${processNames[@]}"; do
-    if echo "$currentProcesses" | /usr/bin/grep -q "$process"; then
-      /bin/launchctl asuser "$loggedInUserUID" /usr/bin/osascript -e "tell application \"${process}\" to quit"
-      echo "Quit ${process}."
-    fi
-  done
+  if echo "$currentProcesses" | /usr/bin/grep -q "${1}"; then
+    /bin/launchctl asuser "$loggedInUserUID" /usr/bin/osascript -e "tell application \"${1}\" to quit"
+    echo "Quit ${1}."
+  fi
+
 }
 
 
-# Removes all remaining resource files.
-delete_files () {
-  for targetFile in "${resourceFiles[@]}"; do
+# Removes specified file.
+delete_file () {
+
     # Check if file exists.
-    if [ -e "$targetFile" ]; then
+    if [ -e "${1}" ]; then
       # Check if file is a plist.
-      if echo "$targetFile" | /usr/bin/grep -q ".plist"; then
+      if echo "${1}" | /usr/bin/grep -q ".plist"; then
         # If plist is loaded as LaunchAgent or LaunchDaemon, unload it.
-        justThePlist=$(/usr/bin/basename "$targetFile" | /usr/bin/awk -F.plist '{print $1}')
-        if echo "$launchAgentCheck" | /usr/bin/grep -q "$justThePlist"; then
-          /bin/launchctl asuser "$loggedInUserUID" /bin/launchctl unload "$targetFile"
-          echo "Unloaded LaunchAgent at ${targetFile}."
-        elif echo "$launchDaemonCheck" | /usr/bin/grep -q "$justThePlist"; then
-          /bin/launchctl unload "$targetFile"
-          echo "Unloaded LaunchDaemon at ${targetFile}."
+        justThePlist=$(/usr/bin/basename "${1}" | /usr/bin/awk -F.plist '{print $1}')
+        if /bin/launchctl asuser "$loggedInUserUID" /bin/launchctl list | /usr/bin/grep -q "$justThePlist"; then
+          /bin/launchctl asuser "$loggedInUserUID" /bin/launchctl unload "${1}"
+          echo "Unloaded LaunchAgent at ${1}."
+        elif /bin/launchctl list | /usr/bin/grep -q "$justThePlist"; then
+          /bin/launchctl unload "${1}"
+          echo "Unloaded LaunchDaemon at ${1}."
         fi
       fi
       # Remove system immutable flag if present.
-      if /bin/ls -ldO "$targetFile" | /usr/bin/awk '{print $5}' | /usr/bin/grep -q "schg"; then
-        /usr/bin/chflags -R noschg "$targetFile"
-        echo "Removed system immutable flag for ${targetFile}."
+      if /bin/ls -ldO "${1}" | /usr/bin/awk '{print $5}' | /usr/bin/grep -q "schg"; then
+        /usr/bin/chflags -R noschg "${1}"
+        echo "Removed system immutable flag for ${1}."
       fi
       # Remove file.
-      /bin/rm -rf "$targetFile"
-      echo "Removed ${targetFile}."
+      /bin/rm -rf "${1}"
+      echo "Removed ${1}."
     fi
-  done
+
 }
 
 
@@ -114,16 +92,19 @@ delete_files () {
 
 
 
-# Each function will only execute if the respective source array is not empty or undefined.
-if [[ -n "${processNames[*]}" ]]; then
-  echo "Quitting processes (if running)..."
-  quit_processes
-fi
+# PROCESSES
+# For each process related to the target product, run the quit_process function calling that process name to quit it. Names should match what is displayed for the process in Activity Monitor (e.g. "Chess", not "Chess.app"). Call the function again for each additional process. If no processes need to be quit, comment out or remove this line.
+quit_process "Adobe Flash Player Install Manager"
 
-if [[ -n "${resourceFiles[*]}" ]]; then
-  echo "Removing files (if present)..."
-  delete_files
-fi
+
+# FILE PATHS
+# For each file and/or folder related to the target product, run the delete_file function calling that file name. Leave off trailing slashes from directory paths. Call the function again for each additional file. If no files need to be deleted, comment out or remove this line.
+delete_file "/Applications/Utilities/Adobe Flash Player Install Manager.app"
+delete_file "/Library/Internet Plug-Ins/Flash Player.plugin"
+delete_file "/Library/Internet Plug-Ins/flashplayer.xpt"
+delete_file "/Library/Internet Plug-Ins/PepperFlashPlayer"
+delete_file "/Library/PreferencePanes/Flash Player.prefPane"
+delete_file "/Library/Receipts/Adobe Flash Player.pkg"
 
 
 

--- a/scripts/script-templates/uninstaller-template/Uninstall Adobe Flash.sh
+++ b/scripts/script-templates/uninstaller-template/Uninstall Adobe Flash.sh
@@ -6,7 +6,7 @@
 #     Description:  A template script to assist with the uninstallation of macOS products where the vendor has missing or incomplete removal solutions. Attempts vendor uninstall by running all provided uninstallation executables, quits all running target processes, then removes all associated target files.
 #                   https://github.com/palantir/jamf-pro-scripts/tree/main/scripts/script-templates/uninstaller-template
 #         Created:  2017-10-23
-#   Last Modified:  2023-07-17
+#   Last Modified:  2023-07-18
 #         Version:  2.0pal1
 #
 #
@@ -60,29 +60,29 @@ quit_process () {
 # Removes specified file.
 delete_file () {
 
-    # Check if file exists.
-    if [ -e "${1}" ]; then
-      # Check if file is a plist.
-      if echo "${1}" | /usr/bin/grep -q ".plist"; then
-        # If plist is loaded as LaunchAgent or LaunchDaemon, unload it.
-        justThePlist=$(/usr/bin/basename "${1}" | /usr/bin/awk -F.plist '{print $1}')
-        if /bin/launchctl asuser "$loggedInUserUID" /bin/launchctl list | /usr/bin/grep -q "$justThePlist"; then
-          /bin/launchctl asuser "$loggedInUserUID" /bin/launchctl unload "${1}"
-          echo "Unloaded LaunchAgent at ${1}."
-        elif /bin/launchctl list | /usr/bin/grep -q "$justThePlist"; then
-          /bin/launchctl unload "${1}"
-          echo "Unloaded LaunchDaemon at ${1}."
-        fi
+  # Check if file exists.
+  if [ -e "${1}" ]; then
+    # Check if file is a plist.
+    if echo "${1}" | /usr/bin/grep -q ".plist"; then
+      # If plist is loaded as LaunchAgent or LaunchDaemon, unload it.
+      justThePlist=$(/usr/bin/basename "${1}" | /usr/bin/awk -F.plist '{print $1}')
+      if /bin/launchctl asuser "$loggedInUserUID" /bin/launchctl list | /usr/bin/grep -q "$justThePlist"; then
+        /bin/launchctl asuser "$loggedInUserUID" /bin/launchctl unload "${1}"
+        echo "Unloaded LaunchAgent at ${1}."
+      elif /bin/launchctl list | /usr/bin/grep -q "$justThePlist"; then
+        /bin/launchctl unload "${1}"
+        echo "Unloaded LaunchDaemon at ${1}."
       fi
-      # Remove system immutable flag if present.
-      if /bin/ls -ldO "${1}" | /usr/bin/awk '{print $5}' | /usr/bin/grep -q "schg"; then
-        /usr/bin/chflags -R noschg "${1}"
-        echo "Removed system immutable flag for ${1}."
-      fi
-      # Remove file.
-      /bin/rm -rf "${1}"
-      echo "Removed ${1}."
     fi
+    # Remove system immutable flag if present.
+    if /bin/ls -ldO "${1}" | /usr/bin/awk '{print $5}' | /usr/bin/grep -q "schg"; then
+      /usr/bin/chflags -R noschg "${1}"
+      echo "Removed system immutable flag for ${1}."
+    fi
+    # Remove file.
+    /bin/rm -rf "${1}"
+    echo "Removed ${1}."
+  fi
 
 }
 

--- a/scripts/script-templates/uninstaller-template/Uninstall AeroFS.sh
+++ b/scripts/script-templates/uninstaller-template/Uninstall AeroFS.sh
@@ -1,13 +1,13 @@
-#!/bin/bash
+#!/bin/sh
 
 ###
 #
 #            Name:  Uninstall AeroFS.sh
-#     Description:  A template script to assist with the uninstallation of macOS products where the vendor has missing or incomplete removal solutions. Attempts vendor uninstall by running all provided uninstallation executables, quits all running target processes, unloads all associated launchd tasks, then removes all associated files.
+#     Description:  A template script to assist with the uninstallation of macOS products where the vendor has missing or incomplete removal solutions. Attempts vendor uninstall by running all provided uninstallation executables, quits all running target processes, then removes all associated target files.
 #                   https://github.com/palantir/jamf-pro-scripts/tree/main/scripts/script-templates/uninstaller-template
 #         Created:  2017-10-23
-#   Last Modified:  2023-05-02
-#         Version:  1.3.10pal1
+#   Last Modified:  2023-07-17
+#         Version:  2.0pal1
 #
 #
 # Copyright 2017 Palantir Technologies, Inc.
@@ -33,30 +33,11 @@
 
 
 
-# ENVIRONMENT VARIABLES (leave as-is)
 loggedInUser=$(/usr/bin/stat -f%Su "/dev/console")
+loggedInUserUID=$(/usr/bin/id -u "$loggedInUser")
 # For any file paths used later in this script, use "$loggedInUserHome" for the current user's home folder path. Don't just assume the home folder is at /Users/${loggedInUser}.
 # shellcheck disable=SC2034
 loggedInUserHome=$(/usr/bin/dscl . -read "/Users/${loggedInUser}" NFSHomeDirectory | /usr/bin/awk '{print $NF}')
-loggedInUserUID=$(/usr/bin/id -u "$loggedInUser")
-launchAgentCheck=$(/bin/launchctl asuser "$loggedInUserUID" /bin/launchctl list)
-launchDaemonCheck=$(/bin/launchctl list)
-
-
-# PROCESSES
-# A list of application processes to target for quitting. Names should match what is displayed for the process in Activity Monitor (e.g. "Chess", not "Chess.app"). If no processes need to be quit, comment these array values out.
-processNames=(
-  "AeroFS"
-)
-
-
-# FILE PATHS
-# A list of full file paths to target for launchd unload and removal. Leave off trailing slashes from directory paths. If no files need to be manually deleted, comment these array values out.
-resourceFiles=(
-  "/Applications/AeroFS.app"
-  "/Library/ScriptingAdditions/AeroFSFinderExtension.osax"
-  "${loggedInUserHome}/Library/Application Support/AeroFS"
-)
 
 
 
@@ -64,45 +45,45 @@ resourceFiles=(
 
 
 
-# Quits target processes.
-quit_processes () {
+# Quits specified process.
+quit_process () {
+
   currentProcesses=$(/bin/ps aux)
-  for process in "${processNames[@]}"; do
-    if echo "$currentProcesses" | /usr/bin/grep -q "$process"; then
-      /bin/launchctl asuser "$loggedInUserUID" /usr/bin/osascript -e "tell application \"${process}\" to quit"
-      echo "Quit ${process}."
-    fi
-  done
+  if echo "$currentProcesses" | /usr/bin/grep -q "${1}"; then
+    /bin/launchctl asuser "$loggedInUserUID" /usr/bin/osascript -e "tell application \"${1}\" to quit"
+    echo "Quit ${1}."
+  fi
+
 }
 
 
-# Removes all remaining resource files.
-delete_files () {
-  for targetFile in "${resourceFiles[@]}"; do
+# Removes specified file.
+delete_file () {
+
     # Check if file exists.
-    if [ -e "$targetFile" ]; then
+    if [ -e "${1}" ]; then
       # Check if file is a plist.
-      if echo "$targetFile" | /usr/bin/grep -q ".plist"; then
+      if echo "${1}" | /usr/bin/grep -q ".plist"; then
         # If plist is loaded as LaunchAgent or LaunchDaemon, unload it.
-        justThePlist=$(/usr/bin/basename "$targetFile" | /usr/bin/awk -F.plist '{print $1}')
-        if echo "$launchAgentCheck" | /usr/bin/grep -q "$justThePlist"; then
-          /bin/launchctl asuser "$loggedInUserUID" /bin/launchctl unload "$targetFile"
-          echo "Unloaded LaunchAgent at ${targetFile}."
-        elif echo "$launchDaemonCheck" | /usr/bin/grep -q "$justThePlist"; then
-          /bin/launchctl unload "$targetFile"
-          echo "Unloaded LaunchDaemon at ${targetFile}."
+        justThePlist=$(/usr/bin/basename "${1}" | /usr/bin/awk -F.plist '{print $1}')
+        if /bin/launchctl asuser "$loggedInUserUID" /bin/launchctl list | /usr/bin/grep -q "$justThePlist"; then
+          /bin/launchctl asuser "$loggedInUserUID" /bin/launchctl unload "${1}"
+          echo "Unloaded LaunchAgent at ${1}."
+        elif /bin/launchctl list | /usr/bin/grep -q "$justThePlist"; then
+          /bin/launchctl unload "${1}"
+          echo "Unloaded LaunchDaemon at ${1}."
         fi
       fi
       # Remove system immutable flag if present.
-      if /bin/ls -ldO "$targetFile" | /usr/bin/awk '{print $5}' | /usr/bin/grep -q "schg"; then
-        /usr/bin/chflags -R noschg "$targetFile"
-        echo "Removed system immutable flag for ${targetFile}."
+      if /bin/ls -ldO "${1}" | /usr/bin/awk '{print $5}' | /usr/bin/grep -q "schg"; then
+        /usr/bin/chflags -R noschg "${1}"
+        echo "Removed system immutable flag for ${1}."
       fi
       # Remove file.
-      /bin/rm -rf "$targetFile"
-      echo "Removed ${targetFile}."
+      /bin/rm -rf "${1}"
+      echo "Removed ${1}."
     fi
-  done
+
 }
 
 
@@ -111,16 +92,16 @@ delete_files () {
 
 
 
-# Each function will only execute if the respective source array is not empty or undefined.
-if [[ -n "${processNames[*]}" ]]; then
-  echo "Quitting processes (if running)..."
-  quit_processes
-fi
+# PROCESSES
+# For each process related to the target product, run the quit_process function calling that process name to quit it. Names should match what is displayed for the process in Activity Monitor (e.g. "Chess", not "Chess.app"). Call the function again for each additional process. If no processes need to be quit, comment out or remove this line.
+quit_process "AeroFS"
 
-if [[ -n "${resourceFiles[*]}" ]]; then
-  echo "Removing files (if present)..."
-  delete_files
-fi
+
+# FILE PATHS
+# For each file and/or folder related to the target product, run the delete_file function calling that file name. Leave off trailing slashes from directory paths. Call the function again for each additional file. If no files need to be deleted, comment out or remove this line.
+delete_file "/Applications/AeroFS.app"
+delete_file "/Library/ScriptingAdditions/AeroFSFinderExtension.osax"
+delete_file "${loggedInUserHome}/Library/Application Support/AeroFS"
 
 
 

--- a/scripts/script-templates/uninstaller-template/Uninstall AeroFS.sh
+++ b/scripts/script-templates/uninstaller-template/Uninstall AeroFS.sh
@@ -6,7 +6,7 @@
 #     Description:  A template script to assist with the uninstallation of macOS products where the vendor has missing or incomplete removal solutions. Attempts vendor uninstall by running all provided uninstallation executables, quits all running target processes, then removes all associated target files.
 #                   https://github.com/palantir/jamf-pro-scripts/tree/main/scripts/script-templates/uninstaller-template
 #         Created:  2017-10-23
-#   Last Modified:  2023-07-17
+#   Last Modified:  2023-07-18
 #         Version:  2.0pal1
 #
 #
@@ -60,29 +60,29 @@ quit_process () {
 # Removes specified file.
 delete_file () {
 
-    # Check if file exists.
-    if [ -e "${1}" ]; then
-      # Check if file is a plist.
-      if echo "${1}" | /usr/bin/grep -q ".plist"; then
-        # If plist is loaded as LaunchAgent or LaunchDaemon, unload it.
-        justThePlist=$(/usr/bin/basename "${1}" | /usr/bin/awk -F.plist '{print $1}')
-        if /bin/launchctl asuser "$loggedInUserUID" /bin/launchctl list | /usr/bin/grep -q "$justThePlist"; then
-          /bin/launchctl asuser "$loggedInUserUID" /bin/launchctl unload "${1}"
-          echo "Unloaded LaunchAgent at ${1}."
-        elif /bin/launchctl list | /usr/bin/grep -q "$justThePlist"; then
-          /bin/launchctl unload "${1}"
-          echo "Unloaded LaunchDaemon at ${1}."
-        fi
+  # Check if file exists.
+  if [ -e "${1}" ]; then
+    # Check if file is a plist.
+    if echo "${1}" | /usr/bin/grep -q ".plist"; then
+      # If plist is loaded as LaunchAgent or LaunchDaemon, unload it.
+      justThePlist=$(/usr/bin/basename "${1}" | /usr/bin/awk -F.plist '{print $1}')
+      if /bin/launchctl asuser "$loggedInUserUID" /bin/launchctl list | /usr/bin/grep -q "$justThePlist"; then
+        /bin/launchctl asuser "$loggedInUserUID" /bin/launchctl unload "${1}"
+        echo "Unloaded LaunchAgent at ${1}."
+      elif /bin/launchctl list | /usr/bin/grep -q "$justThePlist"; then
+        /bin/launchctl unload "${1}"
+        echo "Unloaded LaunchDaemon at ${1}."
       fi
-      # Remove system immutable flag if present.
-      if /bin/ls -ldO "${1}" | /usr/bin/awk '{print $5}' | /usr/bin/grep -q "schg"; then
-        /usr/bin/chflags -R noschg "${1}"
-        echo "Removed system immutable flag for ${1}."
-      fi
-      # Remove file.
-      /bin/rm -rf "${1}"
-      echo "Removed ${1}."
     fi
+    # Remove system immutable flag if present.
+    if /bin/ls -ldO "${1}" | /usr/bin/awk '{print $5}' | /usr/bin/grep -q "schg"; then
+      /usr/bin/chflags -R noschg "${1}"
+      echo "Removed system immutable flag for ${1}."
+    fi
+    # Remove file.
+    /bin/rm -rf "${1}"
+    echo "Removed ${1}."
+  fi
 
 }
 

--- a/scripts/script-templates/uninstaller-template/Uninstall Box Sync.sh
+++ b/scripts/script-templates/uninstaller-template/Uninstall Box Sync.sh
@@ -1,13 +1,13 @@
-#!/bin/bash
+#!/bin/sh
 
 ###
 #
 #            Name:  Uninstall Box Sync.sh
-#     Description:  A template script to assist with the uninstallation of macOS products where the vendor has missing or incomplete removal solutions. Attempts vendor uninstall by running all provided uninstallation executables, quits all running target processes, unloads all associated launchd tasks, then removes all associated files.
+#     Description:  A template script to assist with the uninstallation of macOS products where the vendor has missing or incomplete removal solutions. Attempts vendor uninstall by running all provided uninstallation executables, quits all running target processes, then removes all associated target files.
 #                   https://github.com/palantir/jamf-pro-scripts/tree/main/scripts/script-templates/uninstaller-template
 #         Created:  2017-10-23
-#   Last Modified:  2023-05-02
-#         Version:  1.3.10pal1
+#   Last Modified:  2023-07-17
+#         Version:  2.0pal1
 #
 #
 # Copyright 2017 Palantir Technologies, Inc.
@@ -33,33 +33,11 @@
 
 
 
-# ENVIRONMENT VARIABLES (leave as-is)
 loggedInUser=$(/usr/bin/stat -f%Su "/dev/console")
+loggedInUserUID=$(/usr/bin/id -u "$loggedInUser")
 # For any file paths used later in this script, use "$loggedInUserHome" for the current user's home folder path. Don't just assume the home folder is at /Users/${loggedInUser}.
 # shellcheck disable=SC2034
 loggedInUserHome=$(/usr/bin/dscl . -read "/Users/${loggedInUser}" NFSHomeDirectory | /usr/bin/awk '{print $NF}')
-loggedInUserUID=$(/usr/bin/id -u "$loggedInUser")
-launchAgentCheck=$(/bin/launchctl asuser "$loggedInUserUID" /bin/launchctl list)
-launchDaemonCheck=$(/bin/launchctl list)
-
-
-# PROCESSES
-# A list of application processes to target for quitting. Names should match what is displayed for the process in Activity Monitor (e.g. "Chess", not "Chess.app"). If no processes need to be quit, comment these array values out.
-processNames=(
-  "Box Sync"
-)
-
-
-# FILE PATHS
-# A list of full file paths to target for launchd unload and removal. Leave off trailing slashes from directory paths. If no files need to be manually deleted, comment these array values out.
-resourceFiles=(
-  "/Applications/Box Sync.app"
-  "/Library/PrivilegedHelperTools/com.box.sync.bootstrapper"
-  "/Library/PrivilegedHelperTools/com.box.sync.iconhelper"
-  "${loggedInUserHome}/Library/Logs/Box/Box Sync"
-  "${loggedInUserHome}/Library/Application Support/Box/Box Sync"
-  "${loggedInUserHome}/Box Sync"
-)
 
 
 
@@ -67,45 +45,45 @@ resourceFiles=(
 
 
 
-# Quits target processes.
-quit_processes () {
+# Quits specified process.
+quit_process () {
+
   currentProcesses=$(/bin/ps aux)
-  for process in "${processNames[@]}"; do
-    if echo "$currentProcesses" | /usr/bin/grep -q "$process"; then
-      /bin/launchctl asuser "$loggedInUserUID" /usr/bin/osascript -e "tell application \"${process}\" to quit"
-      echo "Quit ${process}."
-    fi
-  done
+  if echo "$currentProcesses" | /usr/bin/grep -q "${1}"; then
+    /bin/launchctl asuser "$loggedInUserUID" /usr/bin/osascript -e "tell application \"${1}\" to quit"
+    echo "Quit ${1}."
+  fi
+
 }
 
 
-# Removes all remaining resource files.
-delete_files () {
-  for targetFile in "${resourceFiles[@]}"; do
+# Removes specified file.
+delete_file () {
+
     # Check if file exists.
-    if [ -e "$targetFile" ]; then
+    if [ -e "${1}" ]; then
       # Check if file is a plist.
-      if echo "$targetFile" | /usr/bin/grep -q ".plist"; then
+      if echo "${1}" | /usr/bin/grep -q ".plist"; then
         # If plist is loaded as LaunchAgent or LaunchDaemon, unload it.
-        justThePlist=$(/usr/bin/basename "$targetFile" | /usr/bin/awk -F.plist '{print $1}')
-        if echo "$launchAgentCheck" | /usr/bin/grep -q "$justThePlist"; then
-          /bin/launchctl asuser "$loggedInUserUID" /bin/launchctl unload "$targetFile"
-          echo "Unloaded LaunchAgent at ${targetFile}."
-        elif echo "$launchDaemonCheck" | /usr/bin/grep -q "$justThePlist"; then
-          /bin/launchctl unload "$targetFile"
-          echo "Unloaded LaunchDaemon at ${targetFile}."
+        justThePlist=$(/usr/bin/basename "${1}" | /usr/bin/awk -F.plist '{print $1}')
+        if /bin/launchctl asuser "$loggedInUserUID" /bin/launchctl list | /usr/bin/grep -q "$justThePlist"; then
+          /bin/launchctl asuser "$loggedInUserUID" /bin/launchctl unload "${1}"
+          echo "Unloaded LaunchAgent at ${1}."
+        elif /bin/launchctl list | /usr/bin/grep -q "$justThePlist"; then
+          /bin/launchctl unload "${1}"
+          echo "Unloaded LaunchDaemon at ${1}."
         fi
       fi
       # Remove system immutable flag if present.
-      if /bin/ls -ldO "$targetFile" | /usr/bin/awk '{print $5}' | /usr/bin/grep -q "schg"; then
-        /usr/bin/chflags -R noschg "$targetFile"
-        echo "Removed system immutable flag for ${targetFile}."
+      if /bin/ls -ldO "${1}" | /usr/bin/awk '{print $5}' | /usr/bin/grep -q "schg"; then
+        /usr/bin/chflags -R noschg "${1}"
+        echo "Removed system immutable flag for ${1}."
       fi
       # Remove file.
-      /bin/rm -rf "$targetFile"
-      echo "Removed ${targetFile}."
+      /bin/rm -rf "${1}"
+      echo "Removed ${1}."
     fi
-  done
+
 }
 
 
@@ -114,16 +92,19 @@ delete_files () {
 
 
 
-# Each function will only execute if the respective source array is not empty or undefined.
-if [[ -n "${processNames[*]}" ]]; then
-  echo "Quitting processes (if running)..."
-  quit_processes
-fi
+# PROCESSES
+# For each process related to the target product, run the quit_process function calling that process name to quit it. Names should match what is displayed for the process in Activity Monitor (e.g. "Chess", not "Chess.app"). Call the function again for each additional process. If no processes need to be quit, comment out or remove this line.
+quit_process "Box Sync"
 
-if [[ -n "${resourceFiles[*]}" ]]; then
-  echo "Removing files (if present)..."
-  delete_files
-fi
+
+# FILE PATHS
+# For each file and/or folder related to the target product, run the delete_file function calling that file name. Leave off trailing slashes from directory paths. Call the function again for each additional file. If no files need to be deleted, comment out or remove this line.
+delete_file "/Applications/Box Sync.app"
+delete_file "/Library/PrivilegedHelperTools/com.box.sync.bootstrapper"
+delete_file "/Library/PrivilegedHelperTools/com.box.sync.iconhelper"
+delete_file "${loggedInUserHome}/Library/Logs/Box/Box Sync"
+delete_file "${loggedInUserHome}/Library/Application Support/Box/Box Sync"
+delete_file "${loggedInUserHome}/Box Sync"
 
 
 

--- a/scripts/script-templates/uninstaller-template/Uninstall Box Sync.sh
+++ b/scripts/script-templates/uninstaller-template/Uninstall Box Sync.sh
@@ -6,7 +6,7 @@
 #     Description:  A template script to assist with the uninstallation of macOS products where the vendor has missing or incomplete removal solutions. Attempts vendor uninstall by running all provided uninstallation executables, quits all running target processes, then removes all associated target files.
 #                   https://github.com/palantir/jamf-pro-scripts/tree/main/scripts/script-templates/uninstaller-template
 #         Created:  2017-10-23
-#   Last Modified:  2023-07-17
+#   Last Modified:  2023-07-18
 #         Version:  2.0pal1
 #
 #
@@ -60,29 +60,29 @@ quit_process () {
 # Removes specified file.
 delete_file () {
 
-    # Check if file exists.
-    if [ -e "${1}" ]; then
-      # Check if file is a plist.
-      if echo "${1}" | /usr/bin/grep -q ".plist"; then
-        # If plist is loaded as LaunchAgent or LaunchDaemon, unload it.
-        justThePlist=$(/usr/bin/basename "${1}" | /usr/bin/awk -F.plist '{print $1}')
-        if /bin/launchctl asuser "$loggedInUserUID" /bin/launchctl list | /usr/bin/grep -q "$justThePlist"; then
-          /bin/launchctl asuser "$loggedInUserUID" /bin/launchctl unload "${1}"
-          echo "Unloaded LaunchAgent at ${1}."
-        elif /bin/launchctl list | /usr/bin/grep -q "$justThePlist"; then
-          /bin/launchctl unload "${1}"
-          echo "Unloaded LaunchDaemon at ${1}."
-        fi
+  # Check if file exists.
+  if [ -e "${1}" ]; then
+    # Check if file is a plist.
+    if echo "${1}" | /usr/bin/grep -q ".plist"; then
+      # If plist is loaded as LaunchAgent or LaunchDaemon, unload it.
+      justThePlist=$(/usr/bin/basename "${1}" | /usr/bin/awk -F.plist '{print $1}')
+      if /bin/launchctl asuser "$loggedInUserUID" /bin/launchctl list | /usr/bin/grep -q "$justThePlist"; then
+        /bin/launchctl asuser "$loggedInUserUID" /bin/launchctl unload "${1}"
+        echo "Unloaded LaunchAgent at ${1}."
+      elif /bin/launchctl list | /usr/bin/grep -q "$justThePlist"; then
+        /bin/launchctl unload "${1}"
+        echo "Unloaded LaunchDaemon at ${1}."
       fi
-      # Remove system immutable flag if present.
-      if /bin/ls -ldO "${1}" | /usr/bin/awk '{print $5}' | /usr/bin/grep -q "schg"; then
-        /usr/bin/chflags -R noschg "${1}"
-        echo "Removed system immutable flag for ${1}."
-      fi
-      # Remove file.
-      /bin/rm -rf "${1}"
-      echo "Removed ${1}."
     fi
+    # Remove system immutable flag if present.
+    if /bin/ls -ldO "${1}" | /usr/bin/awk '{print $5}' | /usr/bin/grep -q "schg"; then
+      /usr/bin/chflags -R noschg "${1}"
+      echo "Removed system immutable flag for ${1}."
+    fi
+    # Remove file.
+    /bin/rm -rf "${1}"
+    echo "Removed ${1}."
+  fi
 
 }
 

--- a/scripts/script-templates/uninstaller-template/Uninstall Google Santa.sh
+++ b/scripts/script-templates/uninstaller-template/Uninstall Google Santa.sh
@@ -1,13 +1,13 @@
-#!/bin/bash
+#!/bin/sh
 
 ###
 #
 #            Name:  Uninstall Google Santa.sh
-#     Description:  A template script to assist with the uninstallation of macOS products where the vendor has missing or incomplete removal solutions. Attempts vendor uninstall by running all provided uninstallation executables, quits all running target processes, unloads all associated launchd tasks, then removes all associated files.
+#     Description:  A template script to assist with the uninstallation of macOS products where the vendor has missing or incomplete removal solutions. Attempts vendor uninstall by running all provided uninstallation executables, quits all running target processes, then removes all associated target files.
 #                   https://github.com/palantir/jamf-pro-scripts/tree/main/scripts/script-templates/uninstaller-template
 #         Created:  2017-10-23
-#   Last Modified:  2023-05-02
-#         Version:  1.3.10pal1
+#   Last Modified:  2023-07-17
+#         Version:  2.0pal1
 #
 #
 # Copyright 2017 Palantir Technologies, Inc.
@@ -33,40 +33,11 @@
 
 
 
-# ENVIRONMENT VARIABLES (leave as-is)
 loggedInUser=$(/usr/bin/stat -f%Su "/dev/console")
+loggedInUserUID=$(/usr/bin/id -u "$loggedInUser")
 # For any file paths used later in this script, use "$loggedInUserHome" for the current user's home folder path. Don't just assume the home folder is at /Users/${loggedInUser}.
 # shellcheck disable=SC2034
 loggedInUserHome=$(/usr/bin/dscl . -read "/Users/${loggedInUser}" NFSHomeDirectory | /usr/bin/awk '{print $NF}')
-loggedInUserUID=$(/usr/bin/id -u "$loggedInUser")
-launchAgentCheck=$(/bin/launchctl asuser "$loggedInUserUID" /bin/launchctl list)
-launchDaemonCheck=$(/bin/launchctl list)
-
-
-# PROCESSES
-# A list of application processes to target for quitting. Names should match what is displayed for the process in Activity Monitor (e.g. "Chess", not "Chess.app"). If no processes need to be quit, comment these array values out.
-processNames=(
-  "Santa"
-  "santa.ext"
-  "santabs"
-  "santad"
-)
-
-
-# FILE PATHS
-# A list of full file paths to target for launchd unload and removal. Leave off trailing slashes from directory paths. If no files need to be manually deleted, comment these array values out.
-resourceFiles=(
-  "/Applications/Santa.app"
-  "/Library/Extensions/santa-driver.kext"
-  "/Library/LaunchAgents/com.google.santagui.plist"
-  "/Library/LaunchAgents/com.google.santa.plist"
-  "/Library/LaunchDaemons/com.google.santad.plist"
-  "/Library/LaunchDaemons/com.google.santa.bundleservice.plist"
-  "/private/etc/asl/com.google.santa.asl.conf"
-  "/private/etc/newsyslog.d/com.google.santa.newsyslog.conf"
-  "/usr/local/bin/santactl"
-  "/var/db/santa"
-)
 
 
 
@@ -74,45 +45,45 @@ resourceFiles=(
 
 
 
-# Quits target processes.
-quit_processes () {
+# Quits specified process.
+quit_process () {
+
   currentProcesses=$(/bin/ps aux)
-  for process in "${processNames[@]}"; do
-    if echo "$currentProcesses" | /usr/bin/grep -q "$process"; then
-      /bin/launchctl asuser "$loggedInUserUID" /usr/bin/osascript -e "tell application \"${process}\" to quit"
-      echo "Quit ${process}."
-    fi
-  done
+  if echo "$currentProcesses" | /usr/bin/grep -q "${1}"; then
+    /bin/launchctl asuser "$loggedInUserUID" /usr/bin/osascript -e "tell application \"${1}\" to quit"
+    echo "Quit ${1}."
+  fi
+
 }
 
 
-# Removes all remaining resource files.
-delete_files () {
-  for targetFile in "${resourceFiles[@]}"; do
+# Removes specified file.
+delete_file () {
+
     # Check if file exists.
-    if [ -e "$targetFile" ]; then
+    if [ -e "${1}" ]; then
       # Check if file is a plist.
-      if echo "$targetFile" | /usr/bin/grep -q ".plist"; then
+      if echo "${1}" | /usr/bin/grep -q ".plist"; then
         # If plist is loaded as LaunchAgent or LaunchDaemon, unload it.
-        justThePlist=$(/usr/bin/basename "$targetFile" | /usr/bin/awk -F.plist '{print $1}')
-        if echo "$launchAgentCheck" | /usr/bin/grep -q "$justThePlist"; then
-          /bin/launchctl asuser "$loggedInUserUID" /bin/launchctl unload "$targetFile"
-          echo "Unloaded LaunchAgent at ${targetFile}."
-        elif echo "$launchDaemonCheck" | /usr/bin/grep -q "$justThePlist"; then
-          /bin/launchctl unload "$targetFile"
-          echo "Unloaded LaunchDaemon at ${targetFile}."
+        justThePlist=$(/usr/bin/basename "${1}" | /usr/bin/awk -F.plist '{print $1}')
+        if /bin/launchctl asuser "$loggedInUserUID" /bin/launchctl list | /usr/bin/grep -q "$justThePlist"; then
+          /bin/launchctl asuser "$loggedInUserUID" /bin/launchctl unload "${1}"
+          echo "Unloaded LaunchAgent at ${1}."
+        elif /bin/launchctl list | /usr/bin/grep -q "$justThePlist"; then
+          /bin/launchctl unload "${1}"
+          echo "Unloaded LaunchDaemon at ${1}."
         fi
       fi
       # Remove system immutable flag if present.
-      if /bin/ls -ldO "$targetFile" | /usr/bin/awk '{print $5}' | /usr/bin/grep -q "schg"; then
-        /usr/bin/chflags -R noschg "$targetFile"
-        echo "Removed system immutable flag for ${targetFile}."
+      if /bin/ls -ldO "${1}" | /usr/bin/awk '{print $5}' | /usr/bin/grep -q "schg"; then
+        /usr/bin/chflags -R noschg "${1}"
+        echo "Removed system immutable flag for ${1}."
       fi
       # Remove file.
-      /bin/rm -rf "$targetFile"
-      echo "Removed ${targetFile}."
+      /bin/rm -rf "${1}"
+      echo "Removed ${1}."
     fi
-  done
+
 }
 
 
@@ -121,16 +92,26 @@ delete_files () {
 
 
 
-# Each function will only execute if the respective source array is not empty or undefined.
-if [[ -n "${processNames[*]}" ]]; then
-  echo "Quitting processes (if running)..."
-  quit_processes
-fi
+# PROCESSES
+# For each process related to the target product, run the quit_process function calling that process name to quit it. Names should match what is displayed for the process in Activity Monitor (e.g. "Chess", not "Chess.app"). Call the function again for each additional process. If no processes need to be quit, comment out or remove this line.
+quit_process "Santa"
+quit_process "santa.ext"
+quit_process "santabs"
+quit_process "santad"
 
-if [[ -n "${resourceFiles[*]}" ]]; then
-  echo "Removing files (if present)..."
-  delete_files
-fi
+
+# FILE PATHS
+# For each file and/or folder related to the target product, run the delete_file function calling that file name. Leave off trailing slashes from directory paths. Call the function again for each additional file. If no files need to be deleted, comment out or remove this line.
+delete_file "/Applications/Santa.app"
+delete_file "/Library/Extensions/santa-driver.kext"
+delete_file "/Library/LaunchAgents/com.google.santagui.plist"
+delete_file "/Library/LaunchAgents/com.google.santa.plist"
+delete_file "/Library/LaunchDaemons/com.google.santad.plist"
+delete_file "/Library/LaunchDaemons/com.google.santa.bundleservice.plist"
+delete_file "/private/etc/asl/com.google.santa.asl.conf"
+delete_file "/private/etc/newsyslog.d/com.google.santa.newsyslog.conf"
+delete_file "/usr/local/bin/santactl"
+delete_file "/var/db/santa"
 
 
 

--- a/scripts/script-templates/uninstaller-template/Uninstall Google Santa.sh
+++ b/scripts/script-templates/uninstaller-template/Uninstall Google Santa.sh
@@ -6,7 +6,7 @@
 #     Description:  A template script to assist with the uninstallation of macOS products where the vendor has missing or incomplete removal solutions. Attempts vendor uninstall by running all provided uninstallation executables, quits all running target processes, then removes all associated target files.
 #                   https://github.com/palantir/jamf-pro-scripts/tree/main/scripts/script-templates/uninstaller-template
 #         Created:  2017-10-23
-#   Last Modified:  2023-07-17
+#   Last Modified:  2023-07-18
 #         Version:  2.0pal1
 #
 #
@@ -60,29 +60,29 @@ quit_process () {
 # Removes specified file.
 delete_file () {
 
-    # Check if file exists.
-    if [ -e "${1}" ]; then
-      # Check if file is a plist.
-      if echo "${1}" | /usr/bin/grep -q ".plist"; then
-        # If plist is loaded as LaunchAgent or LaunchDaemon, unload it.
-        justThePlist=$(/usr/bin/basename "${1}" | /usr/bin/awk -F.plist '{print $1}')
-        if /bin/launchctl asuser "$loggedInUserUID" /bin/launchctl list | /usr/bin/grep -q "$justThePlist"; then
-          /bin/launchctl asuser "$loggedInUserUID" /bin/launchctl unload "${1}"
-          echo "Unloaded LaunchAgent at ${1}."
-        elif /bin/launchctl list | /usr/bin/grep -q "$justThePlist"; then
-          /bin/launchctl unload "${1}"
-          echo "Unloaded LaunchDaemon at ${1}."
-        fi
+  # Check if file exists.
+  if [ -e "${1}" ]; then
+    # Check if file is a plist.
+    if echo "${1}" | /usr/bin/grep -q ".plist"; then
+      # If plist is loaded as LaunchAgent or LaunchDaemon, unload it.
+      justThePlist=$(/usr/bin/basename "${1}" | /usr/bin/awk -F.plist '{print $1}')
+      if /bin/launchctl asuser "$loggedInUserUID" /bin/launchctl list | /usr/bin/grep -q "$justThePlist"; then
+        /bin/launchctl asuser "$loggedInUserUID" /bin/launchctl unload "${1}"
+        echo "Unloaded LaunchAgent at ${1}."
+      elif /bin/launchctl list | /usr/bin/grep -q "$justThePlist"; then
+        /bin/launchctl unload "${1}"
+        echo "Unloaded LaunchDaemon at ${1}."
       fi
-      # Remove system immutable flag if present.
-      if /bin/ls -ldO "${1}" | /usr/bin/awk '{print $5}' | /usr/bin/grep -q "schg"; then
-        /usr/bin/chflags -R noschg "${1}"
-        echo "Removed system immutable flag for ${1}."
-      fi
-      # Remove file.
-      /bin/rm -rf "${1}"
-      echo "Removed ${1}."
     fi
+    # Remove system immutable flag if present.
+    if /bin/ls -ldO "${1}" | /usr/bin/awk '{print $5}' | /usr/bin/grep -q "schg"; then
+      /usr/bin/chflags -R noschg "${1}"
+      echo "Removed system immutable flag for ${1}."
+    fi
+    # Remove file.
+    /bin/rm -rf "${1}"
+    echo "Removed ${1}."
+  fi
 
 }
 

--- a/scripts/script-templates/uninstaller-template/Uninstall Osquery.sh
+++ b/scripts/script-templates/uninstaller-template/Uninstall Osquery.sh
@@ -1,13 +1,13 @@
-#!/bin/bash
+#!/bin/sh
 
 ###
 #
 #            Name:  Uninstall Osquery.sh
-#     Description:  A template script to assist with the uninstallation of macOS products where the vendor has missing or incomplete removal solutions. Attempts vendor uninstall by running all provided uninstallation executables, quits all running target processes, unloads all associated launchd tasks, then removes all associated files.
+#     Description:  A template script to assist with the uninstallation of macOS products where the vendor has missing or incomplete removal solutions. Attempts vendor uninstall by running all provided uninstallation executables, quits all running target processes, then removes all associated target files.
 #                   https://github.com/palantir/jamf-pro-scripts/tree/main/scripts/script-templates/uninstaller-template
 #         Created:  2017-10-23
-#   Last Modified:  2023-05-02
-#         Version:  1.3.10pal1
+#   Last Modified:  2023-07-17
+#         Version:  2.0pal1
 #
 #
 # Copyright 2017 Palantir Technologies, Inc.
@@ -33,38 +33,11 @@
 
 
 
-# ENVIRONMENT VARIABLES (leave as-is)
 loggedInUser=$(/usr/bin/stat -f%Su "/dev/console")
+loggedInUserUID=$(/usr/bin/id -u "$loggedInUser")
 # For any file paths used later in this script, use "$loggedInUserHome" for the current user's home folder path. Don't just assume the home folder is at /Users/${loggedInUser}.
 # shellcheck disable=SC2034
 loggedInUserHome=$(/usr/bin/dscl . -read "/Users/${loggedInUser}" NFSHomeDirectory | /usr/bin/awk '{print $NF}')
-loggedInUserUID=$(/usr/bin/id -u "$loggedInUser")
-launchAgentCheck=$(/bin/launchctl asuser "$loggedInUserUID" /bin/launchctl list)
-launchDaemonCheck=$(/bin/launchctl list)
-
-
-# PROCESSES
-# A list of application processes to target for quitting. Names should match what is displayed for the process in Activity Monitor (e.g. "Chess", not "Chess.app"). If no processes need to be quit, comment these array values out.
-processNames=(
-  "osqueryctl"
-  "osqueryd"
-  "osqueryi"
-)
-
-
-# FILE PATHS
-# A list of full file paths to target for launchd unload and removal. Leave off trailing slashes from directory paths. If no files need to be manually deleted, comment these array values out.
-resourceFiles=(
-  "/Library/LaunchDaemons/com.facebook.osqueryd.plist"
-  "/Library/LaunchDaemons/io.osquery.agent.plist"
-  "/opt/osquery/lib/osquery.app"
-  "/opt/osquery"
-  "/private/var/log/osquery"
-  "/private/var/osquery"
-  "/usr/local/bin/osqueryctl"
-  "/usr/local/bin/osqueryd"
-  "/usr/local/bin/osqueryi"
-)
 
 
 
@@ -72,45 +45,45 @@ resourceFiles=(
 
 
 
-# Quits target processes.
-quit_processes () {
+# Quits specified process.
+quit_process () {
+
   currentProcesses=$(/bin/ps aux)
-  for process in "${processNames[@]}"; do
-    if echo "$currentProcesses" | /usr/bin/grep -q "$process"; then
-      /bin/launchctl asuser "$loggedInUserUID" /usr/bin/osascript -e "tell application \"${process}\" to quit"
-      echo "Quit ${process}."
-    fi
-  done
+  if echo "$currentProcesses" | /usr/bin/grep -q "${1}"; then
+    /bin/launchctl asuser "$loggedInUserUID" /usr/bin/osascript -e "tell application \"${1}\" to quit"
+    echo "Quit ${1}."
+  fi
+
 }
 
 
-# Removes all remaining resource files.
-delete_files () {
-  for targetFile in "${resourceFiles[@]}"; do
+# Removes specified file.
+delete_file () {
+
     # Check if file exists.
-    if [ -e "$targetFile" ]; then
+    if [ -e "${1}" ]; then
       # Check if file is a plist.
-      if echo "$targetFile" | /usr/bin/grep -q ".plist"; then
+      if echo "${1}" | /usr/bin/grep -q ".plist"; then
         # If plist is loaded as LaunchAgent or LaunchDaemon, unload it.
-        justThePlist=$(/usr/bin/basename "$targetFile" | /usr/bin/awk -F.plist '{print $1}')
-        if echo "$launchAgentCheck" | /usr/bin/grep -q "$justThePlist"; then
-          /bin/launchctl asuser "$loggedInUserUID" /bin/launchctl unload "$targetFile"
-          echo "Unloaded LaunchAgent at ${targetFile}."
-        elif echo "$launchDaemonCheck" | /usr/bin/grep -q "$justThePlist"; then
-          /bin/launchctl unload "$targetFile"
-          echo "Unloaded LaunchDaemon at ${targetFile}."
+        justThePlist=$(/usr/bin/basename "${1}" | /usr/bin/awk -F.plist '{print $1}')
+        if /bin/launchctl asuser "$loggedInUserUID" /bin/launchctl list | /usr/bin/grep -q "$justThePlist"; then
+          /bin/launchctl asuser "$loggedInUserUID" /bin/launchctl unload "${1}"
+          echo "Unloaded LaunchAgent at ${1}."
+        elif /bin/launchctl list | /usr/bin/grep -q "$justThePlist"; then
+          /bin/launchctl unload "${1}"
+          echo "Unloaded LaunchDaemon at ${1}."
         fi
       fi
       # Remove system immutable flag if present.
-      if /bin/ls -ldO "$targetFile" | /usr/bin/awk '{print $5}' | /usr/bin/grep -q "schg"; then
-        /usr/bin/chflags -R noschg "$targetFile"
-        echo "Removed system immutable flag for ${targetFile}."
+      if /bin/ls -ldO "${1}" | /usr/bin/awk '{print $5}' | /usr/bin/grep -q "schg"; then
+        /usr/bin/chflags -R noschg "${1}"
+        echo "Removed system immutable flag for ${1}."
       fi
       # Remove file.
-      /bin/rm -rf "$targetFile"
-      echo "Removed ${targetFile}."
+      /bin/rm -rf "${1}"
+      echo "Removed ${1}."
     fi
-  done
+
 }
 
 
@@ -119,16 +92,24 @@ delete_files () {
 
 
 
-# Each function will only execute if the respective source array is not empty or undefined.
-if [[ -n "${processNames[*]}" ]]; then
-  echo "Quitting processes (if running)..."
-  quit_processes
-fi
+# PROCESSES
+# For each process related to the target product, run the quit_process function calling that process name to quit it. Names should match what is displayed for the process in Activity Monitor (e.g. "Chess", not "Chess.app"). Call the function again for each additional process. If no processes need to be quit, comment out or remove this line.
+quit_process "osqueryctl"
+quit_process "osqueryd"
+quit_process "osqueryi"
 
-if [[ -n "${resourceFiles[*]}" ]]; then
-  echo "Removing files (if present)..."
-  delete_files
-fi
+
+# FILE PATHS
+# For each file and/or folder related to the target product, run the delete_file function calling that file name. Leave off trailing slashes from directory paths. Call the function again for each additional file. If no files need to be deleted, comment out or remove this line.
+delete_file "/Library/LaunchDaemons/com.facebook.osqueryd.plist"
+delete_file "/Library/LaunchDaemons/io.osquery.agent.plist"
+delete_file "/opt/osquery/lib/osquery.app"
+delete_file "/opt/osquery"
+delete_file "/private/var/log/osquery"
+delete_file "/private/var/osquery"
+delete_file "/usr/local/bin/osqueryctl"
+delete_file "/usr/local/bin/osqueryd"
+delete_file "/usr/local/bin/osqueryi"
 
 
 

--- a/scripts/script-templates/uninstaller-template/Uninstall Osquery.sh
+++ b/scripts/script-templates/uninstaller-template/Uninstall Osquery.sh
@@ -6,7 +6,7 @@
 #     Description:  A template script to assist with the uninstallation of macOS products where the vendor has missing or incomplete removal solutions. Attempts vendor uninstall by running all provided uninstallation executables, quits all running target processes, then removes all associated target files.
 #                   https://github.com/palantir/jamf-pro-scripts/tree/main/scripts/script-templates/uninstaller-template
 #         Created:  2017-10-23
-#   Last Modified:  2023-07-17
+#   Last Modified:  2023-07-18
 #         Version:  2.0pal1
 #
 #
@@ -60,29 +60,29 @@ quit_process () {
 # Removes specified file.
 delete_file () {
 
-    # Check if file exists.
-    if [ -e "${1}" ]; then
-      # Check if file is a plist.
-      if echo "${1}" | /usr/bin/grep -q ".plist"; then
-        # If plist is loaded as LaunchAgent or LaunchDaemon, unload it.
-        justThePlist=$(/usr/bin/basename "${1}" | /usr/bin/awk -F.plist '{print $1}')
-        if /bin/launchctl asuser "$loggedInUserUID" /bin/launchctl list | /usr/bin/grep -q "$justThePlist"; then
-          /bin/launchctl asuser "$loggedInUserUID" /bin/launchctl unload "${1}"
-          echo "Unloaded LaunchAgent at ${1}."
-        elif /bin/launchctl list | /usr/bin/grep -q "$justThePlist"; then
-          /bin/launchctl unload "${1}"
-          echo "Unloaded LaunchDaemon at ${1}."
-        fi
+  # Check if file exists.
+  if [ -e "${1}" ]; then
+    # Check if file is a plist.
+    if echo "${1}" | /usr/bin/grep -q ".plist"; then
+      # If plist is loaded as LaunchAgent or LaunchDaemon, unload it.
+      justThePlist=$(/usr/bin/basename "${1}" | /usr/bin/awk -F.plist '{print $1}')
+      if /bin/launchctl asuser "$loggedInUserUID" /bin/launchctl list | /usr/bin/grep -q "$justThePlist"; then
+        /bin/launchctl asuser "$loggedInUserUID" /bin/launchctl unload "${1}"
+        echo "Unloaded LaunchAgent at ${1}."
+      elif /bin/launchctl list | /usr/bin/grep -q "$justThePlist"; then
+        /bin/launchctl unload "${1}"
+        echo "Unloaded LaunchDaemon at ${1}."
       fi
-      # Remove system immutable flag if present.
-      if /bin/ls -ldO "${1}" | /usr/bin/awk '{print $5}' | /usr/bin/grep -q "schg"; then
-        /usr/bin/chflags -R noschg "${1}"
-        echo "Removed system immutable flag for ${1}."
-      fi
-      # Remove file.
-      /bin/rm -rf "${1}"
-      echo "Removed ${1}."
     fi
+    # Remove system immutable flag if present.
+    if /bin/ls -ldO "${1}" | /usr/bin/awk '{print $5}' | /usr/bin/grep -q "schg"; then
+      /usr/bin/chflags -R noschg "${1}"
+      echo "Removed system immutable flag for ${1}."
+    fi
+    # Remove file.
+    /bin/rm -rf "${1}"
+    echo "Removed ${1}."
+  fi
 
 }
 

--- a/scripts/script-templates/uninstaller-template/Uninstall Pulse Secure.sh
+++ b/scripts/script-templates/uninstaller-template/Uninstall Pulse Secure.sh
@@ -1,13 +1,13 @@
-#!/bin/bash
+#!/bin/sh
 
 ###
 #
 #            Name:  Uninstall Pulse Secure.sh
-#     Description:  A template script to assist with the uninstallation of macOS products where the vendor has missing or incomplete removal solutions. Attempts vendor uninstall by running all provided uninstallation executables, quits all running target processes, unloads all associated launchd tasks, then removes all associated files.
+#     Description:  A template script to assist with the uninstallation of macOS products where the vendor has missing or incomplete removal solutions. Attempts vendor uninstall by running all provided uninstallation executables, quits all running target processes, then removes all associated target files.
 #                   https://github.com/palantir/jamf-pro-scripts/tree/main/scripts/script-templates/uninstaller-template
 #         Created:  2017-10-23
-#   Last Modified:  2023-05-02
-#         Version:  1.3.10pal1
+#   Last Modified:  2023-07-17
+#         Version:  2.0pal1
 #
 #
 # Copyright 2017 Palantir Technologies, Inc.
@@ -33,51 +33,11 @@
 
 
 
-# ENVIRONMENT VARIABLES (leave as-is)
 loggedInUser=$(/usr/bin/stat -f%Su "/dev/console")
+loggedInUserUID=$(/usr/bin/id -u "$loggedInUser")
 # For any file paths used later in this script, use "$loggedInUserHome" for the current user's home folder path. Don't just assume the home folder is at /Users/${loggedInUser}.
 # shellcheck disable=SC2034
 loggedInUserHome=$(/usr/bin/dscl . -read "/Users/${loggedInUser}" NFSHomeDirectory | /usr/bin/awk '{print $NF}')
-loggedInUserUID=$(/usr/bin/id -u "$loggedInUser")
-launchAgentCheck=$(/bin/launchctl asuser "$loggedInUserUID" /bin/launchctl list)
-launchDaemonCheck=$(/bin/launchctl list)
-
-
-# VENDOR UNINSTALLERS
-# A list of file paths for vendor-provided uninstallation tools.
-# Note that vendor uninstaller workflows may differ greatly. Some vendors may
-# use their own command-line tools with custom flags or other workflows to
-# accomplish this task (that's why this script exists!), so make any necessary
-# changes to the below commands if the uninstallation workflow isn't simply
-# calling executable files.
-#
-# If the vendor did not provide an uninstaller workflow, comment these array
-# values out.
-vendorUninstallers=(
-  "/Library/Application Support/Juniper Networks/Junos Pulse/Uninstall.app/Contents/Resources/uninstall.sh"
-  "/Library/Application Support/Pulse Secure/Pulse/Uninstall.app/Contents/Resources/uninstall.sh"
-)
-
-
-# PROCESSES
-# A list of application processes to target for quitting. Names should match what is displayed for the process in Activity Monitor (e.g. "Chess", not "Chess.app"). If no processes need to be quit, comment these array values out.
-processNames=(
-  "Junos Pulse"
-  "Pulse Secure"
-)
-
-
-# FILE PATHS
-# A list of full file paths to target for launchd unload and removal. Leave off trailing slashes from directory paths. If no files need to be manually deleted, comment these array values out.
-resourceFiles=(
-  "/Applications/Junos Pulse.app"
-  "/Applications/Pulse Secure.app"
-  "/Library/Application Support/Juniper Networks/Junos Pulse"
-  "/Library/Application Support/Pulse Secure"
-  "/Library/LaunchAgents/net.pulsesecure.pulsetray.plist"
-  "/Library/LaunchDaemons/net.pulsesecure.AccessService.plist"
-  "/Library/LaunchDaemons/net.pulsesecure.UninstallPulse.plist"
-)
 
 
 
@@ -85,57 +45,58 @@ resourceFiles=(
 
 
 
-# Runs vendor uninstallers.
-run_vendor_uninstallers () {
-  for uninstaller in "${vendorUninstallers[@]}"; do
-    if [[ -e "$uninstaller" ]]; then
-      ./"${uninstaller}"
-    else
-      echo "Vendor uninstaller not found at ${uninstaller}."
-    fi
-  done
+# Runs specified vendor uninstaller.
+run_vendor_uninstaller () {
+
+  if [ -e "${1}" ]; then
+    echo "Running vendor uninstaller: ${1}"
+    ./"${1}"
+  else
+    echo "Vendor uninstaller not found at ${1}."
+  fi
+
 }
 
 
-# Quits target processes.
-quit_processes () {
+# Quits specified process.
+quit_process () {
+
   currentProcesses=$(/bin/ps aux)
-  for process in "${processNames[@]}"; do
-    if echo "$currentProcesses" | /usr/bin/grep -q "$process"; then
-      /bin/launchctl asuser "$loggedInUserUID" /usr/bin/osascript -e "tell application \"${process}\" to quit"
-      echo "Quit ${process}."
-    fi
-  done
+  if echo "$currentProcesses" | /usr/bin/grep -q "${1}"; then
+    /bin/launchctl asuser "$loggedInUserUID" /usr/bin/osascript -e "tell application \"${1}\" to quit"
+    echo "Quit ${1}."
+  fi
+
 }
 
 
-# Removes all remaining resource files.
-delete_files () {
-  for targetFile in "${resourceFiles[@]}"; do
+# Removes specified file.
+delete_file () {
+
     # Check if file exists.
-    if [ -e "$targetFile" ]; then
+    if [ -e "${1}" ]; then
       # Check if file is a plist.
-      if echo "$targetFile" | /usr/bin/grep -q ".plist"; then
+      if echo "${1}" | /usr/bin/grep -q ".plist"; then
         # If plist is loaded as LaunchAgent or LaunchDaemon, unload it.
-        justThePlist=$(/usr/bin/basename "$targetFile" | /usr/bin/awk -F.plist '{print $1}')
-        if echo "$launchAgentCheck" | /usr/bin/grep -q "$justThePlist"; then
-          /bin/launchctl asuser "$loggedInUserUID" /bin/launchctl unload "$targetFile"
-          echo "Unloaded LaunchAgent at ${targetFile}."
-        elif echo "$launchDaemonCheck" | /usr/bin/grep -q "$justThePlist"; then
-          /bin/launchctl unload "$targetFile"
-          echo "Unloaded LaunchDaemon at ${targetFile}."
+        justThePlist=$(/usr/bin/basename "${1}" | /usr/bin/awk -F.plist '{print $1}')
+        if /bin/launchctl asuser "$loggedInUserUID" /bin/launchctl list | /usr/bin/grep -q "$justThePlist"; then
+          /bin/launchctl asuser "$loggedInUserUID" /bin/launchctl unload "${1}"
+          echo "Unloaded LaunchAgent at ${1}."
+        elif /bin/launchctl list | /usr/bin/grep -q "$justThePlist"; then
+          /bin/launchctl unload "${1}"
+          echo "Unloaded LaunchDaemon at ${1}."
         fi
       fi
       # Remove system immutable flag if present.
-      if /bin/ls -ldO "$targetFile" | /usr/bin/awk '{print $5}' | /usr/bin/grep -q "schg"; then
-        /usr/bin/chflags -R noschg "$targetFile"
-        echo "Removed system immutable flag for ${targetFile}."
+      if /bin/ls -ldO "${1}" | /usr/bin/awk '{print $5}' | /usr/bin/grep -q "schg"; then
+        /usr/bin/chflags -R noschg "${1}"
+        echo "Removed system immutable flag for ${1}."
       fi
       # Remove file.
-      /bin/rm -rf "$targetFile"
-      echo "Removed ${targetFile}."
+      /bin/rm -rf "${1}"
+      echo "Removed ${1}."
     fi
-  done
+
 }
 
 
@@ -144,21 +105,27 @@ delete_files () {
 
 
 
-# Each function will only execute if the respective source array is not empty or undefined.
-if [[ -n "${vendorUninstallers[*]}" ]]; then
-  echo "Running vendor uninstallers..."
-  run_vendor_uninstallers
-fi
+# VENDOR UNINSTALLERS
+# For each vendor-provided uninstallation tool file path that exists on the system, run the run_vendor_uninstaller function calling that path to run it. Note that vendor uninstaller workflows may differ greatly from app to app. Some vendors may use their own command-line tools with custom flags or other workflows to accomplish this task (that's why this script exists!), so make any necessary changes to the below commands if the uninstallation workflow isn't simply calling executable files. Call the function again for each additional uninstaller. If the vendor did not provide an uninstaller workflow, comment out or remove this line.
+run_vendor_uninstaller "/Library/Application Support/Juniper Networks/Junos Pulse/Uninstall.app/Contents/Resources/uninstall.sh"
+run_vendor_uninstaller "/Library/Application Support/Pulse Secure/Pulse/Uninstall.app/Contents/Resources/uninstall.sh"
 
-if [[ -n "${processNames[*]}" ]]; then
-  echo "Quitting processes (if running)..."
-  quit_processes
-fi
 
-if [[ -n "${resourceFiles[*]}" ]]; then
-  echo "Removing files (if present)..."
-  delete_files
-fi
+# PROCESSES
+# For each process related to the target product, run the quit_process function calling that process name to quit it. Names should match what is displayed for the process in Activity Monitor (e.g. "Chess", not "Chess.app"). Call the function again for each additional process. If no processes need to be quit, comment out or remove this line.
+quit_process "Junos Pulse"
+quit_process "Pulse Secure"
+
+
+# FILE PATHS
+# For each file and/or folder related to the target product, run the delete_file function calling that file name. Leave off trailing slashes from directory paths. Call the function again for each additional file. If no files need to be deleted, comment out or remove this line.
+delete_file "/Applications/Junos Pulse.app"
+delete_file "/Applications/Pulse Secure.app"
+delete_file "/Library/Application Support/Juniper Networks/Junos Pulse"
+delete_file "/Library/Application Support/Pulse Secure"
+delete_file "/Library/LaunchAgents/net.pulsesecure.pulsetray.plist"
+delete_file "/Library/LaunchDaemons/net.pulsesecure.AccessService.plist"
+delete_file "/Library/LaunchDaemons/net.pulsesecure.UninstallPulse.plist"
 
 
 

--- a/scripts/script-templates/uninstaller-template/Uninstall Pulse Secure.sh
+++ b/scripts/script-templates/uninstaller-template/Uninstall Pulse Secure.sh
@@ -6,7 +6,7 @@
 #     Description:  A template script to assist with the uninstallation of macOS products where the vendor has missing or incomplete removal solutions. Attempts vendor uninstall by running all provided uninstallation executables, quits all running target processes, then removes all associated target files.
 #                   https://github.com/palantir/jamf-pro-scripts/tree/main/scripts/script-templates/uninstaller-template
 #         Created:  2017-10-23
-#   Last Modified:  2023-07-17
+#   Last Modified:  2023-07-18
 #         Version:  2.0pal1
 #
 #
@@ -73,29 +73,29 @@ quit_process () {
 # Removes specified file.
 delete_file () {
 
-    # Check if file exists.
-    if [ -e "${1}" ]; then
-      # Check if file is a plist.
-      if echo "${1}" | /usr/bin/grep -q ".plist"; then
-        # If plist is loaded as LaunchAgent or LaunchDaemon, unload it.
-        justThePlist=$(/usr/bin/basename "${1}" | /usr/bin/awk -F.plist '{print $1}')
-        if /bin/launchctl asuser "$loggedInUserUID" /bin/launchctl list | /usr/bin/grep -q "$justThePlist"; then
-          /bin/launchctl asuser "$loggedInUserUID" /bin/launchctl unload "${1}"
-          echo "Unloaded LaunchAgent at ${1}."
-        elif /bin/launchctl list | /usr/bin/grep -q "$justThePlist"; then
-          /bin/launchctl unload "${1}"
-          echo "Unloaded LaunchDaemon at ${1}."
-        fi
+  # Check if file exists.
+  if [ -e "${1}" ]; then
+    # Check if file is a plist.
+    if echo "${1}" | /usr/bin/grep -q ".plist"; then
+      # If plist is loaded as LaunchAgent or LaunchDaemon, unload it.
+      justThePlist=$(/usr/bin/basename "${1}" | /usr/bin/awk -F.plist '{print $1}')
+      if /bin/launchctl asuser "$loggedInUserUID" /bin/launchctl list | /usr/bin/grep -q "$justThePlist"; then
+        /bin/launchctl asuser "$loggedInUserUID" /bin/launchctl unload "${1}"
+        echo "Unloaded LaunchAgent at ${1}."
+      elif /bin/launchctl list | /usr/bin/grep -q "$justThePlist"; then
+        /bin/launchctl unload "${1}"
+        echo "Unloaded LaunchDaemon at ${1}."
       fi
-      # Remove system immutable flag if present.
-      if /bin/ls -ldO "${1}" | /usr/bin/awk '{print $5}' | /usr/bin/grep -q "schg"; then
-        /usr/bin/chflags -R noschg "${1}"
-        echo "Removed system immutable flag for ${1}."
-      fi
-      # Remove file.
-      /bin/rm -rf "${1}"
-      echo "Removed ${1}."
     fi
+    # Remove system immutable flag if present.
+    if /bin/ls -ldO "${1}" | /usr/bin/awk '{print $5}' | /usr/bin/grep -q "schg"; then
+      /usr/bin/chflags -R noschg "${1}"
+      echo "Removed system immutable flag for ${1}."
+    fi
+    # Remove file.
+    /bin/rm -rf "${1}"
+    echo "Removed ${1}."
+  fi
 
 }
 

--- a/scripts/script-templates/uninstaller-template/Uninstall Silverlight.sh
+++ b/scripts/script-templates/uninstaller-template/Uninstall Silverlight.sh
@@ -6,7 +6,7 @@
 #     Description:  A template script to assist with the uninstallation of macOS products where the vendor has missing or incomplete removal solutions. Attempts vendor uninstall by running all provided uninstallation executables, quits all running target processes, then removes all associated target files.
 #                   https://github.com/palantir/jamf-pro-scripts/tree/main/scripts/script-templates/uninstaller-template
 #         Created:  2017-10-23
-#   Last Modified:  2023-07-17
+#   Last Modified:  2023-07-18
 #         Version:  2.0pal1
 #
 #
@@ -48,29 +48,29 @@ loggedInUserHome=$(/usr/bin/dscl . -read "/Users/${loggedInUser}" NFSHomeDirecto
 # Removes specified file.
 delete_file () {
 
-    # Check if file exists.
-    if [ -e "${1}" ]; then
-      # Check if file is a plist.
-      if echo "${1}" | /usr/bin/grep -q ".plist"; then
-        # If plist is loaded as LaunchAgent or LaunchDaemon, unload it.
-        justThePlist=$(/usr/bin/basename "${1}" | /usr/bin/awk -F.plist '{print $1}')
-        if /bin/launchctl asuser "$loggedInUserUID" /bin/launchctl list | /usr/bin/grep -q "$justThePlist"; then
-          /bin/launchctl asuser "$loggedInUserUID" /bin/launchctl unload "${1}"
-          echo "Unloaded LaunchAgent at ${1}."
-        elif /bin/launchctl list | /usr/bin/grep -q "$justThePlist"; then
-          /bin/launchctl unload "${1}"
-          echo "Unloaded LaunchDaemon at ${1}."
-        fi
+  # Check if file exists.
+  if [ -e "${1}" ]; then
+    # Check if file is a plist.
+    if echo "${1}" | /usr/bin/grep -q ".plist"; then
+      # If plist is loaded as LaunchAgent or LaunchDaemon, unload it.
+      justThePlist=$(/usr/bin/basename "${1}" | /usr/bin/awk -F.plist '{print $1}')
+      if /bin/launchctl asuser "$loggedInUserUID" /bin/launchctl list | /usr/bin/grep -q "$justThePlist"; then
+        /bin/launchctl asuser "$loggedInUserUID" /bin/launchctl unload "${1}"
+        echo "Unloaded LaunchAgent at ${1}."
+      elif /bin/launchctl list | /usr/bin/grep -q "$justThePlist"; then
+        /bin/launchctl unload "${1}"
+        echo "Unloaded LaunchDaemon at ${1}."
       fi
-      # Remove system immutable flag if present.
-      if /bin/ls -ldO "${1}" | /usr/bin/awk '{print $5}' | /usr/bin/grep -q "schg"; then
-        /usr/bin/chflags -R noschg "${1}"
-        echo "Removed system immutable flag for ${1}."
-      fi
-      # Remove file.
-      /bin/rm -rf "${1}"
-      echo "Removed ${1}."
     fi
+    # Remove system immutable flag if present.
+    if /bin/ls -ldO "${1}" | /usr/bin/awk '{print $5}' | /usr/bin/grep -q "schg"; then
+      /usr/bin/chflags -R noschg "${1}"
+      echo "Removed system immutable flag for ${1}."
+    fi
+    # Remove file.
+    /bin/rm -rf "${1}"
+    echo "Removed ${1}."
+  fi
 
 }
 

--- a/scripts/script-templates/uninstaller-template/Uninstall Silverlight.sh
+++ b/scripts/script-templates/uninstaller-template/Uninstall Silverlight.sh
@@ -1,13 +1,13 @@
-#!/bin/bash
+#!/bin/sh
 
 ###
 #
 #            Name:  Uninstall Silverlight.sh
-#     Description:  A template script to assist with the uninstallation of macOS products where the vendor has missing or incomplete removal solutions. Attempts vendor uninstall by running all provided uninstallation executables, quits all running target processes, unloads all associated launchd tasks, then removes all associated files.
+#     Description:  A template script to assist with the uninstallation of macOS products where the vendor has missing or incomplete removal solutions. Attempts vendor uninstall by running all provided uninstallation executables, quits all running target processes, then removes all associated target files.
 #                   https://github.com/palantir/jamf-pro-scripts/tree/main/scripts/script-templates/uninstaller-template
 #         Created:  2017-10-23
-#   Last Modified:  2023-05-02
-#         Version:  1.3.10pal1
+#   Last Modified:  2023-07-17
+#         Version:  2.0pal1
 #
 #
 # Copyright 2017 Palantir Technologies, Inc.
@@ -33,25 +33,11 @@
 
 
 
-# ENVIRONMENT VARIABLES (leave as-is)
 loggedInUser=$(/usr/bin/stat -f%Su "/dev/console")
+loggedInUserUID=$(/usr/bin/id -u "$loggedInUser")
 # For any file paths used later in this script, use "$loggedInUserHome" for the current user's home folder path. Don't just assume the home folder is at /Users/${loggedInUser}.
 # shellcheck disable=SC2034
 loggedInUserHome=$(/usr/bin/dscl . -read "/Users/${loggedInUser}" NFSHomeDirectory | /usr/bin/awk '{print $NF}')
-loggedInUserUID=$(/usr/bin/id -u "$loggedInUser")
-launchAgentCheck=$(/bin/launchctl asuser "$loggedInUserUID" /bin/launchctl list)
-launchDaemonCheck=$(/bin/launchctl list)
-
-
-# FILE PATHS
-# A list of full file paths to target for launchd unload and removal. Leave off trailing slashes from directory paths. If no files need to be manually deleted, comment these array values out.
-resourceFiles=(
-  "/Library/Internet Plug-Ins/Silverlight.plugin"
-  "/Library/Internet Plug-Ins/WPFe.plugin"
-  "${loggedInUserHome}/Library/Application Support/Microsoft/Silverlight"
-  "/var/db/receipts/com.microsoft.SilverlightInstaller.bom"
-  "/var/db/receipts/com.microsoft.SilverlightInstaller.plist"
-)
 
 
 
@@ -59,33 +45,33 @@ resourceFiles=(
 
 
 
-# Removes all remaining resource files.
-delete_files () {
-  for targetFile in "${resourceFiles[@]}"; do
+# Removes specified file.
+delete_file () {
+
     # Check if file exists.
-    if [ -e "$targetFile" ]; then
+    if [ -e "${1}" ]; then
       # Check if file is a plist.
-      if echo "$targetFile" | /usr/bin/grep -q ".plist"; then
+      if echo "${1}" | /usr/bin/grep -q ".plist"; then
         # If plist is loaded as LaunchAgent or LaunchDaemon, unload it.
-        justThePlist=$(/usr/bin/basename "$targetFile" | /usr/bin/awk -F.plist '{print $1}')
-        if echo "$launchAgentCheck" | /usr/bin/grep -q "$justThePlist"; then
-          /bin/launchctl asuser "$loggedInUserUID" /bin/launchctl unload "$targetFile"
-          echo "Unloaded LaunchAgent at ${targetFile}."
-        elif echo "$launchDaemonCheck" | /usr/bin/grep -q "$justThePlist"; then
-          /bin/launchctl unload "$targetFile"
-          echo "Unloaded LaunchDaemon at ${targetFile}."
+        justThePlist=$(/usr/bin/basename "${1}" | /usr/bin/awk -F.plist '{print $1}')
+        if /bin/launchctl asuser "$loggedInUserUID" /bin/launchctl list | /usr/bin/grep -q "$justThePlist"; then
+          /bin/launchctl asuser "$loggedInUserUID" /bin/launchctl unload "${1}"
+          echo "Unloaded LaunchAgent at ${1}."
+        elif /bin/launchctl list | /usr/bin/grep -q "$justThePlist"; then
+          /bin/launchctl unload "${1}"
+          echo "Unloaded LaunchDaemon at ${1}."
         fi
       fi
       # Remove system immutable flag if present.
-      if /bin/ls -ldO "$targetFile" | /usr/bin/awk '{print $5}' | /usr/bin/grep -q "schg"; then
-        /usr/bin/chflags -R noschg "$targetFile"
-        echo "Removed system immutable flag for ${targetFile}."
+      if /bin/ls -ldO "${1}" | /usr/bin/awk '{print $5}' | /usr/bin/grep -q "schg"; then
+        /usr/bin/chflags -R noschg "${1}"
+        echo "Removed system immutable flag for ${1}."
       fi
       # Remove file.
-      /bin/rm -rf "$targetFile"
-      echo "Removed ${targetFile}."
+      /bin/rm -rf "${1}"
+      echo "Removed ${1}."
     fi
-  done
+
 }
 
 
@@ -94,11 +80,13 @@ delete_files () {
 
 
 
-# Each function will only execute if the respective source array is not empty or undefined.
-if [[ -n "${resourceFiles[*]}" ]]; then
-  echo "Removing files (if present)..."
-  delete_files
-fi
+# FILE PATHS
+# For each file and/or folder related to the target product, run the delete_file function calling that file name. Leave off trailing slashes from directory paths. Call the function again for each additional file. If no files need to be deleted, comment out or remove this line.
+delete_file "/Library/Internet Plug-Ins/Silverlight.plugin"
+delete_file "/Library/Internet Plug-Ins/WPFe.plugin"
+delete_file "${loggedInUserHome}/Library/Application Support/Microsoft/Silverlight"
+delete_file "/var/db/receipts/com.microsoft.SilverlightInstaller.bom"
+delete_file "/var/db/receipts/com.microsoft.SilverlightInstaller.plist"
 
 
 

--- a/scripts/script-templates/uninstaller-template/Uninstall Single Application.sh
+++ b/scripts/script-templates/uninstaller-template/Uninstall Single Application.sh
@@ -1,13 +1,13 @@
-#!/bin/bash
+#!/bin/sh
 
 ###
 #
 #            Name:  Uninstall Single Application.sh
-#     Description:  A template script to assist with the uninstallation of macOS products where the vendor has missing or incomplete removal solutions. Attempts vendor uninstall by running all provided uninstallation executables, quits all running target processes, unloads all associated launchd tasks, then removes all associated files.
+#     Description:  A template script to assist with the uninstallation of macOS products where the vendor has missing or incomplete removal solutions. Attempts vendor uninstall by running all provided uninstallation executables, quits all running target processes, then removes all associated target files.
 #                   https://github.com/palantir/jamf-pro-scripts/tree/main/scripts/script-templates/uninstaller-template
 #         Created:  2017-10-23
-#   Last Modified:  2023-05-02
-#         Version:  1.3.10pal1
+#   Last Modified:  2023-07-17
+#         Version:  2.0pal1
 #
 #
 # Copyright 2017 Palantir Technologies, Inc.
@@ -33,24 +33,18 @@
 
 
 
-# ENVIRONMENT VARIABLES (leave as-is)
+# Jamf Pro script parameter: "App Process"
+appProcess="${4}"
+# Jamf Pro script parameter: "App File Path"
+# Should be full path to the application, e.g. "/System/Applications/Chess.app"
+appFilePath="${5}"
+
+
 loggedInUser=$(/usr/bin/stat -f%Su "/dev/console")
+loggedInUserUID=$(/usr/bin/id -u "$loggedInUser")
 # For any file paths used later in this script, use "$loggedInUserHome" for the current user's home folder path. Don't just assume the home folder is at /Users/${loggedInUser}.
 # shellcheck disable=SC2034
 loggedInUserHome=$(/usr/bin/dscl . -read "/Users/${loggedInUser}" NFSHomeDirectory | /usr/bin/awk '{print $NF}')
-loggedInUserUID=$(/usr/bin/id -u "$loggedInUser")
-launchAgentCheck=$(/bin/launchctl asuser "$loggedInUserUID" /bin/launchctl list)
-launchDaemonCheck=$(/bin/launchctl list)
-
-
-# PROCESSES
-# A list of application processes to target for quitting. Names should match what is displayed for the process in Activity Monitor (e.g. "Chess", not "Chess.app"). If no processes need to be quit, comment these array values out.
-process="${4}" # Jamf Pro script parameter: "App Process"
-
-
-# FILE PATHS
-# A list of full file paths to target for launchd unload and removal. Leave off trailing slashes from directory paths. If no files need to be manually deleted, comment these array values out.
-targetFile="${5}" # Jamf Pro script parameter: "App File Path"; should be full path to the application, e.g. "/System/Applications/Chess.app"
 
 
 
@@ -60,48 +54,54 @@ targetFile="${5}" # Jamf Pro script parameter: "App File Path"; should be full p
 
 # Exit if any required Jamf Pro arguments are undefined.
 check_jamf_pro_arguments () {
+
   if [ -z "$process" ] || [ -z "$targetFile" ]; then
     echo "❌ ERROR: Undefined Jamf Pro argument, unable to proceed."
     exit 74
   fi
+
 }
 
 
-# Quit target processes.
-quit_processes () {
+# Quits specified process.
+quit_process () {
+
   currentProcesses=$(/bin/ps aux)
-  if echo "$currentProcesses" | /usr/bin/grep -q "$process"; then
-    /bin/launchctl asuser "$loggedInUserUID" /usr/bin/osascript -e "tell application \"${process}\" to quit"
-    echo "Quit ${process}."
+  if echo "$currentProcesses" | /usr/bin/grep -q "${1}"; then
+    /bin/launchctl asuser "$loggedInUserUID" /usr/bin/osascript -e "tell application \"${1}\" to quit"
+    echo "Quit ${1}."
   fi
+
 }
 
 
-# Remove all remaining resource files.
-delete_files () {
-  # Check if file exists.
-  if [ -e "$targetFile" ]; then
-    # Check if file is a plist.
-    if echo "$targetFile" | /usr/bin/grep -q ".plist"; then
-      # If plist is loaded as LaunchAgent or LaunchDaemon, unload it.
-      justThePlist=$(/usr/bin/basename "$targetFile" | /usr/bin/awk -F.plist '{print $1}')
-      if echo "$launchAgentCheck" | /usr/bin/grep -q "$justThePlist"; then
-        /bin/launchctl asuser "$loggedInUserUID" /bin/launchctl unload "$targetFile"
-        echo "Unloaded LaunchAgent at ${targetFile}."
-      elif echo "$launchDaemonCheck" | /usr/bin/grep -q "$justThePlist"; then
-        /bin/launchctl unload "$targetFile"
-        echo "Unloaded LaunchDaemon at ${targetFile}."
+# Removes specified file.
+delete_file () {
+
+    # Check if file exists.
+    if [ -e "${1}" ]; then
+      # Check if file is a plist.
+      if echo "${1}" | /usr/bin/grep -q ".plist"; then
+        # If plist is loaded as LaunchAgent or LaunchDaemon, unload it.
+        justThePlist=$(/usr/bin/basename "${1}" | /usr/bin/awk -F.plist '{print $1}')
+        if /bin/launchctl asuser "$loggedInUserUID" /bin/launchctl list | /usr/bin/grep -q "$justThePlist"; then
+          /bin/launchctl asuser "$loggedInUserUID" /bin/launchctl unload "${1}"
+          echo "Unloaded LaunchAgent at ${1}."
+        elif /bin/launchctl list | /usr/bin/grep -q "$justThePlist"; then
+          /bin/launchctl unload "${1}"
+          echo "Unloaded LaunchDaemon at ${1}."
+        fi
       fi
+      # Remove system immutable flag if present.
+      if /bin/ls -ldO "${1}" | /usr/bin/awk '{print $5}' | /usr/bin/grep -q "schg"; then
+        /usr/bin/chflags -R noschg "${1}"
+        echo "Removed system immutable flag for ${1}."
+      fi
+      # Remove file.
+      /bin/rm -rf "${1}"
+      echo "Removed ${1}."
     fi
-    # Remove system immutable flag if present.
-    if /bin/ls -ldO "$targetFile" | /usr/bin/awk '{print $5}' | /usr/bin/grep -q "schg"; then
-      /usr/bin/chflags -R noschg "$targetFile"
-      echo "Removed system immutable flag for ${targetFile}."
-    fi
-    # Remove file.
-    /bin/rm -rf "$targetFile"
-    echo "Removed ${targetFile}."
-  fi
+
 }
 
 
@@ -114,16 +114,14 @@ delete_files () {
 check_jamf_pro_arguments
 
 
-# Each function will only execute if the respective source array is not empty or undefined.
-if [ -n "${process}" ]; then
-  echo "Quitting process (if running)..."
-  quit_processes
-fi
+# PROCESSES
+# For each process related to the target product, run the quit_process function calling that process name to quit it. Names should match what is displayed for the process in Activity Monitor (e.g. "Chess", not "Chess.app"). Call the function again for each additional process. If no processes need to be quit, comment out or remove this line.
+quit_process "$appProcess"
 
-if [ -n "${targetFile}" ]; then
-  echo "Removing files (if present)..."
-  delete_files
-fi
+
+# FILE PATHS
+# For each file and/or folder related to the target product, run the delete_file function calling that file name. Leave off trailing slashes from directory paths. Call the function again for each additional file. If no files need to be deleted, comment out or remove this line.
+delete_file "$appFilePath"
 
 
 

--- a/scripts/script-templates/uninstaller-template/Uninstall Single Application.sh
+++ b/scripts/script-templates/uninstaller-template/Uninstall Single Application.sh
@@ -6,7 +6,7 @@
 #     Description:  A template script to assist with the uninstallation of macOS products where the vendor has missing or incomplete removal solutions. Attempts vendor uninstall by running all provided uninstallation executables, quits all running target processes, then removes all associated target files.
 #                   https://github.com/palantir/jamf-pro-scripts/tree/main/scripts/script-templates/uninstaller-template
 #         Created:  2017-10-23
-#   Last Modified:  2023-07-17
+#   Last Modified:  2023-07-18
 #         Version:  2.0pal1
 #
 #
@@ -78,29 +78,29 @@ quit_process () {
 # Removes specified file.
 delete_file () {
 
-    # Check if file exists.
-    if [ -e "${1}" ]; then
-      # Check if file is a plist.
-      if echo "${1}" | /usr/bin/grep -q ".plist"; then
-        # If plist is loaded as LaunchAgent or LaunchDaemon, unload it.
-        justThePlist=$(/usr/bin/basename "${1}" | /usr/bin/awk -F.plist '{print $1}')
-        if /bin/launchctl asuser "$loggedInUserUID" /bin/launchctl list | /usr/bin/grep -q "$justThePlist"; then
-          /bin/launchctl asuser "$loggedInUserUID" /bin/launchctl unload "${1}"
-          echo "Unloaded LaunchAgent at ${1}."
-        elif /bin/launchctl list | /usr/bin/grep -q "$justThePlist"; then
-          /bin/launchctl unload "${1}"
-          echo "Unloaded LaunchDaemon at ${1}."
-        fi
+  # Check if file exists.
+  if [ -e "${1}" ]; then
+    # Check if file is a plist.
+    if echo "${1}" | /usr/bin/grep -q ".plist"; then
+      # If plist is loaded as LaunchAgent or LaunchDaemon, unload it.
+      justThePlist=$(/usr/bin/basename "${1}" | /usr/bin/awk -F.plist '{print $1}')
+      if /bin/launchctl asuser "$loggedInUserUID" /bin/launchctl list | /usr/bin/grep -q "$justThePlist"; then
+        /bin/launchctl asuser "$loggedInUserUID" /bin/launchctl unload "${1}"
+        echo "Unloaded LaunchAgent at ${1}."
+      elif /bin/launchctl list | /usr/bin/grep -q "$justThePlist"; then
+        /bin/launchctl unload "${1}"
+        echo "Unloaded LaunchDaemon at ${1}."
       fi
-      # Remove system immutable flag if present.
-      if /bin/ls -ldO "${1}" | /usr/bin/awk '{print $5}' | /usr/bin/grep -q "schg"; then
-        /usr/bin/chflags -R noschg "${1}"
-        echo "Removed system immutable flag for ${1}."
-      fi
-      # Remove file.
-      /bin/rm -rf "${1}"
-      echo "Removed ${1}."
     fi
+    # Remove system immutable flag if present.
+    if /bin/ls -ldO "${1}" | /usr/bin/awk '{print $5}' | /usr/bin/grep -q "schg"; then
+      /usr/bin/chflags -R noschg "${1}"
+      echo "Removed system immutable flag for ${1}."
+    fi
+    # Remove file.
+    /bin/rm -rf "${1}"
+    echo "Removed ${1}."
+  fi
 
 }
 

--- a/scripts/script-templates/uninstaller-template/Uninstall Single Application.sh
+++ b/scripts/script-templates/uninstaller-template/Uninstall Single Application.sh
@@ -55,7 +55,7 @@ loggedInUserHome=$(/usr/bin/dscl . -read "/Users/${loggedInUser}" NFSHomeDirecto
 # Exit if any required Jamf Pro arguments are undefined.
 check_jamf_pro_arguments () {
 
-  if [ -z "$process" ] || [ -z "$targetFile" ]; then
+  if [ -z "$appProcess" ] || [ -z "$appFilePath" ]; then
     echo "❌ ERROR: Undefined Jamf Pro argument, unable to proceed."
     exit 74
   fi

--- a/scripts/script-templates/uninstaller-template/Uninstall Single Application.sh
+++ b/scripts/script-templates/uninstaller-template/Uninstall Single Application.sh
@@ -6,7 +6,7 @@
 #     Description:  A template script to assist with the uninstallation of macOS products where the vendor has missing or incomplete removal solutions. Attempts vendor uninstall by running all provided uninstallation executables, quits all running target processes, then removes all associated target files.
 #                   https://github.com/palantir/jamf-pro-scripts/tree/main/scripts/script-templates/uninstaller-template
 #         Created:  2017-10-23
-#   Last Modified:  2023-07-18
+#   Last Modified:  2023-07-24
 #         Version:  2.0pal1
 #
 #

--- a/scripts/script-templates/uninstaller-template/uninstaller-template.sh
+++ b/scripts/script-templates/uninstaller-template/uninstaller-template.sh
@@ -6,7 +6,7 @@
 #     Description:  A template script to assist with the uninstallation of macOS products where the vendor has missing or incomplete removal solutions. Attempts vendor uninstall by running all provided uninstallation executables, quits all running target processes, then removes all associated target files.
 #                   https://github.com/palantir/jamf-pro-scripts/tree/main/scripts/script-templates/uninstaller-template
 #         Created:  2017-10-23
-#   Last Modified:  2023-07-17
+#   Last Modified:  2023-07-18
 #         Version:  2.0
 #
 #
@@ -73,29 +73,29 @@ quit_process () {
 # Removes specified file.
 delete_file () {
 
-    # Check if file exists.
-    if [ -e "${1}" ]; then
-      # Check if file is a plist.
-      if echo "${1}" | /usr/bin/grep -q ".plist"; then
-        # If plist is loaded as LaunchAgent or LaunchDaemon, unload it.
-        justThePlist=$(/usr/bin/basename "${1}" | /usr/bin/awk -F.plist '{print $1}')
-        if /bin/launchctl asuser "$loggedInUserUID" /bin/launchctl list | /usr/bin/grep -q "$justThePlist"; then
-          /bin/launchctl asuser "$loggedInUserUID" /bin/launchctl unload "${1}"
-          echo "Unloaded LaunchAgent at ${1}."
-        elif /bin/launchctl list | /usr/bin/grep -q "$justThePlist"; then
-          /bin/launchctl unload "${1}"
-          echo "Unloaded LaunchDaemon at ${1}."
-        fi
+  # Check if file exists.
+  if [ -e "${1}" ]; then
+    # Check if file is a plist.
+    if echo "${1}" | /usr/bin/grep -q ".plist"; then
+      # If plist is loaded as LaunchAgent or LaunchDaemon, unload it.
+      justThePlist=$(/usr/bin/basename "${1}" | /usr/bin/awk -F.plist '{print $1}')
+      if /bin/launchctl asuser "$loggedInUserUID" /bin/launchctl list | /usr/bin/grep -q "$justThePlist"; then
+        /bin/launchctl asuser "$loggedInUserUID" /bin/launchctl unload "${1}"
+        echo "Unloaded LaunchAgent at ${1}."
+      elif /bin/launchctl list | /usr/bin/grep -q "$justThePlist"; then
+        /bin/launchctl unload "${1}"
+        echo "Unloaded LaunchDaemon at ${1}."
       fi
-      # Remove system immutable flag if present.
-      if /bin/ls -ldO "${1}" | /usr/bin/awk '{print $5}' | /usr/bin/grep -q "schg"; then
-        /usr/bin/chflags -R noschg "${1}"
-        echo "Removed system immutable flag for ${1}."
-      fi
-      # Remove file.
-      /bin/rm -rf "${1}"
-      echo "Removed ${1}."
     fi
+    # Remove system immutable flag if present.
+    if /bin/ls -ldO "${1}" | /usr/bin/awk '{print $5}' | /usr/bin/grep -q "schg"; then
+      /usr/bin/chflags -R noschg "${1}"
+      echo "Removed system immutable flag for ${1}."
+    fi
+    # Remove file.
+    /bin/rm -rf "${1}"
+    echo "Removed ${1}."
+  fi
 
 }
 

--- a/scripts/script-templates/uninstaller-template/uninstaller-template.sh
+++ b/scripts/script-templates/uninstaller-template/uninstaller-template.sh
@@ -1,13 +1,13 @@
-#!/bin/bash
+#!/bin/sh
 
 ###
 #
 #            Name:  uninstaller-template.sh
-#     Description:  A template script to assist with the uninstallation of macOS products where the vendor has missing or incomplete removal solutions. Attempts vendor uninstall by running all provided uninstallation executables, quits all running target processes, unloads all associated launchd tasks, then removes all associated files.
+#     Description:  A template script to assist with the uninstallation of macOS products where the vendor has missing or incomplete removal solutions. Attempts vendor uninstall by running all provided uninstallation executables, quits all running target processes, then removes all associated target files.
 #                   https://github.com/palantir/jamf-pro-scripts/tree/main/scripts/script-templates/uninstaller-template
 #         Created:  2017-10-23
-#   Last Modified:  2023-05-02
-#         Version:  1.3.10
+#   Last Modified:  2023-07-17
+#         Version:  2.0
 #
 #
 # Copyright 2017 Palantir Technologies, Inc.
@@ -33,7 +33,6 @@
 
 
 
-# ENVIRONMENT VARIABLES (leave as-is)
 loggedInUser=$(/usr/bin/stat -f%Su "/dev/console")
 # For any file paths used later in this script, use "$loggedInUserHome" for the current user's home folder path. Don't just assume the home folder is at /Users/${loggedInUser}.
 # shellcheck disable=SC2034
@@ -43,86 +42,63 @@ launchAgentCheck=$(/bin/launchctl asuser "$loggedInUserUID" /bin/launchctl list)
 launchDaemonCheck=$(/bin/launchctl list)
 
 
-# VENDOR UNINSTALLERS
-# A list of file paths for vendor-provided uninstallation tools. Note that vendor uninstaller workflows may differ greatly. Some vendors may use their own command-line tools with custom flags or other workflows to accomplish this task (that's why this script exists!), so make any necessary changes to the below commands if the uninstallation workflow isn't simply calling executable files. If the vendor did not provide an uninstaller workflow, comment these array values out.
-vendorUninstallers=(
-  "/path/to/vendor_uninstaller_command1.sh"
-  "/path/to/vendor_uninstaller_command2.sh"
-)
-
-
-# PROCESSES
-# A list of application processes to target for quitting. Names should match what is displayed for the process in Activity Monitor (e.g. "Chess", not "Chess.app"). If no processes need to be quit, comment these array values out.
-processNames=(
-  "Process Name 1"
-  "Process Name 2"
-)
-
-
-# FILE PATHS
-# A list of full file paths to target for launchd unload and removal. Leave off trailing slashes from directory paths. If no files need to be manually deleted, comment these array values out.
-resourceFiles=(
-  "/path/to/file1"
-  "/path/to/file2"
-)
-
-
 
 ########## function-ing ##########
 
 
 
-# Runs vendor uninstallers.
-run_vendor_uninstallers () {
-  for uninstaller in "${vendorUninstallers[@]}"; do
-    if [[ -e "$uninstaller" ]]; then
-      ./"${uninstaller}"
-    else
-      echo "Vendor uninstaller not found at ${uninstaller}."
-    fi
-  done
+# Runs specified vendor uninstaller.
+run_vendor_uninstaller () {
+
+  if [ -e "${1}" ]; then
+    echo "Running vendor uninstaller: ${1}"
+    ./"${1}"
+  else
+    echo "Vendor uninstaller not found at ${1}."
+  fi
+
 }
 
 
-# Quits target processes.
-quit_processes () {
+# Quits specified process.
+quit_process () {
+
   currentProcesses=$(/bin/ps aux)
-  for process in "${processNames[@]}"; do
-    if echo "$currentProcesses" | /usr/bin/grep -q "$process"; then
-      /bin/launchctl asuser "$loggedInUserUID" /usr/bin/osascript -e "tell application \"${process}\" to quit"
-      echo "Quit ${process}."
-    fi
-  done
+  if echo "$currentProcesses" | /usr/bin/grep -q "${1}"; then
+    /bin/launchctl asuser "$loggedInUserUID" /usr/bin/osascript -e "tell application \"${1}\" to quit"
+    echo "Quit ${1}."
+  fi
+
 }
 
 
-# Removes all remaining resource files.
-delete_files () {
-  for targetFile in "${resourceFiles[@]}"; do
+# Removes specified file.
+delete_file () {
+
     # Check if file exists.
-    if [ -e "$targetFile" ]; then
+    if [ -e "${1}" ]; then
       # Check if file is a plist.
-      if echo "$targetFile" | /usr/bin/grep -q ".plist"; then
+      if echo "${1}" | /usr/bin/grep -q ".plist"; then
         # If plist is loaded as LaunchAgent or LaunchDaemon, unload it.
-        justThePlist=$(/usr/bin/basename "$targetFile" | /usr/bin/awk -F.plist '{print $1}')
+        justThePlist=$(/usr/bin/basename "${1}" | /usr/bin/awk -F.plist '{print $1}')
         if echo "$launchAgentCheck" | /usr/bin/grep -q "$justThePlist"; then
-          /bin/launchctl asuser "$loggedInUserUID" /bin/launchctl unload "$targetFile"
-          echo "Unloaded LaunchAgent at ${targetFile}."
+          /bin/launchctl asuser "$loggedInUserUID" /bin/launchctl unload "${1}"
+          echo "Unloaded LaunchAgent at ${1}."
         elif echo "$launchDaemonCheck" | /usr/bin/grep -q "$justThePlist"; then
-          /bin/launchctl unload "$targetFile"
-          echo "Unloaded LaunchDaemon at ${targetFile}."
+          /bin/launchctl unload "${1}"
+          echo "Unloaded LaunchDaemon at ${1}."
         fi
       fi
       # Remove system immutable flag if present.
-      if /bin/ls -ldO "$targetFile" | /usr/bin/awk '{print $5}' | /usr/bin/grep -q "schg"; then
-        /usr/bin/chflags -R noschg "$targetFile"
-        echo "Removed system immutable flag for ${targetFile}."
+      if /bin/ls -ldO "${1}" | /usr/bin/awk '{print $5}' | /usr/bin/grep -q "schg"; then
+        /usr/bin/chflags -R noschg "${1}"
+        echo "Removed system immutable flag for ${1}."
       fi
       # Remove file.
-      /bin/rm -rf "$targetFile"
-      echo "Removed ${targetFile}."
+      /bin/rm -rf "${1}"
+      echo "Removed ${1}."
     fi
-  done
+
 }
 
 
@@ -131,21 +107,19 @@ delete_files () {
 
 
 
-# Each function will only execute if the respective source array is not empty or undefined.
-if [[ -n "${vendorUninstallers[*]}" ]]; then
-  echo "Running vendor uninstallers..."
-  run_vendor_uninstallers
-fi
+# VENDOR UNINSTALLERS
+# For each vendor-provided uninstallation tool file path that exists on the system, run the run_vendor_uninstaller function calling that path to run it. Note that vendor uninstaller workflows may differ greatly from app to app. Some vendors may use their own command-line tools with custom flags or other workflows to accomplish this task (that's why this script exists!), so make any necessary changes to the below commands if the uninstallation workflow isn't simply calling executable files. Call the function again for each additional uninstaller. If the vendor did not provide an uninstaller workflow, comment out or remove this line.
+run_vendor_uninstaller "/path/to/vendor_uninstaller_command.sh"
 
-if [[ -n "${processNames[*]}" ]]; then
-  echo "Quitting processes (if running)..."
-  quit_processes
-fi
 
-if [[ -n "${resourceFiles[*]}" ]]; then
-  echo "Removing files (if present)..."
-  delete_files
-fi
+# PROCESSES
+# For each process related to the target product, run the quit_process function calling that process name to quit it. Names should match what is displayed for the process in Activity Monitor (e.g. "Chess", not "Chess.app"). Call the function again for each additional process. If no processes need to be quit, comment out or remove this line.
+quit_process "Process Name"
+
+
+# FILE PATHS
+# For each file and/or folder related to the target product, run the delete_file function calling that file name. Leave off trailing slashes from directory paths. Call the function again for each additional file. If no files need to be deleted, comment out or remove this line.
+delete_file "/path/to/file"
 
 
 


### PR DESCRIPTION
- converted uninstaller-template.sh to POSIX Shell
  - moved arrays to individual function runs for each specified file path or process name
- moved launchd checks to delete_file function (avoids being called if no .plists are targeted)
- removed variable capture for launchd checks (script now just runs the check each time it's looking for an associated launchd job)
- updated all uninstall scripts with template changes
- moved custom script parameters above default variables
- expanded versioning advice in README